### PR TITLE
issue-2 adding 'paper' layout and support for layout config

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -42,7 +42,7 @@ pub struct Config {
 /* Argument enums */
 
 /// A direction to permute a Ring
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Direction {
     /// increase the index, wrapping if needed
     Forward,
@@ -152,6 +152,13 @@ impl<T> Ring<T> {
             elements: elements.into(),
             focused: 0,
         }
+    }
+
+    pub fn would_wrap(&self, dir: Direction) -> bool {
+        let wrap_back = self.focused == 0 && dir == Direction::Backward;
+        let wrap_forward = self.focused == self.elements.len() - 1 && dir == Direction::Forward;
+
+        wrap_back || wrap_forward
     }
 
     pub fn focused(&self) -> Option<&T> {

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -11,8 +11,8 @@
 extern crate penrose;
 
 use penrose::helpers::spawn;
-use penrose::layout::{bottom_stack, side_stack};
-use penrose::{ColorScheme, Config, Layout, LayoutKind, WindowManager, XcbConnection};
+use penrose::layout::{bottom_stack, paper, side_stack};
+use penrose::{ColorScheme, Config, Layout, LayoutConf, WindowManager, XcbConnection};
 use simplelog;
 use std::env;
 use std::process::Command;
@@ -41,12 +41,18 @@ fn main() {
         urgent: 0x458588,    // #458588
     };
 
+    let follow_focus_conf = LayoutConf {
+        floating: false,
+        gapless: true,
+        follow_focus: true,
+    };
     let n_main = 1;
     let ratio = 0.6;
     let layouts = vec![
-        Layout::new("[side]", LayoutKind::Normal, side_stack, n_main, ratio),
-        Layout::new("[botm]", LayoutKind::Normal, bottom_stack, n_main, ratio),
-        // Layout::new("[    ]", LayoutKind::Floating, floating, n_main, ratio),
+        Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
+        Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
+        Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
+        Layout::floating("[    ]"),
     ];
 
     // I run penrose wrapped in a shell script that redirects the log output to a file and allows

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@ pub mod xconnection;
 
 // top level re-exports
 pub use data_types::{ColorScheme, Config};
-pub use layout::{Layout, LayoutKind};
+pub use layout::{Layout, LayoutConf};
 pub use manager::WindowManager;
 pub use xconnection::XcbConnection;


### PR DESCRIPTION
Fixes #2 

![paper](https://user-images.githubusercontent.com/8116092/87885956-345d3580-ca11-11ea-9693-899dd37fb94d.gif)

In order to get paper to work, we need the layout to be triggered each time focus is gained by a new client, we also need to ensure that this does not result in an infinite loop of constantly recomputing layouts when wrapping from one side of the screen to the other. In theory this should be doable but try as I might, there were a lot of issues with getting that working smoothly without the layout function itself having to handle it. As a compromise, enabling 'follow_focus' for a given layout will enable this behaviour of triggering on focus change but at the cost of preventing wrapping clients when cycling focus or dragging through the stack. This prevents the edge case from arising at the cost of a slightly more cumbersome experience if you want to move a client from one end of the stack to the other.
Since I was already adding that in, we now support floating layouts (though no mouse support for moving a client yet) and the ability to disable gaps on chosen layouts if wanted.