### PR TITLE
Issue 6/preventing zombies

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -3,10 +3,11 @@ use crate::layout::Layout;
 use crate::manager::WindowManager;
 use std::collections::{HashMap, VecDeque};
 use std::ops;
+use std::process::Child;
 use xcb;
 
 /// Some action to be run by a user key binding
-pub type FireAndForget = Box<dyn Fn(&mut WindowManager) -> ()>;
+pub type FireAndForget = Box<dyn Fn(&mut WindowManager) -> Option<Child>>;
 
 /// User defined key bindings
 pub type KeyBindings = HashMap<KeyCode, FireAndForget>;

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -68,6 +68,7 @@ fn main() {
             "restart-wm\n" => wm.exit(),
             _ => (), // 'no', user exited out or something went wrong
         }
+        None
     });
 
     // Set the root X window name to be the active layout symbol so it can be picked up by polybar
@@ -104,10 +105,12 @@ fn main() {
         "M-grave" => Box::new(move |wm| {
             wm.next_layout();
             active_layout_as_root_name(wm);
+            None
         }),
         "M-S-grave" => Box::new(move |wm| {
             wm.previous_layout();
             active_layout_as_root_name(wm);
+            None
         }),
         "M-A-Up" => run_internal!(inc_main),
         "M-A-Down" => run_internal!(dec_main),

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -52,7 +52,7 @@ fn main() {
         Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
         Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
         Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
-        Layout::floating("[    ]"),
+        Layout::floating("[----]"),
     ];
 
     // I run penrose wrapped in a shell script that redirects the log output to a file and allows

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,21 +1,6 @@
 //! Utility macros for use in the rest of penrose.
 //! Not intended for general use
 
-/// use notify-send to trigger a pop up window with a message (used for debugging)
-#[macro_export]
-macro_rules! notify(
-    ($msg:expr) => {
-        ::std::process::Command::new("notify-send").arg($msg).spawn().unwrap();
-    };
-
-    ($fmt:expr, $($arg:expr),*) => {
-        ::std::process::Command::new("notify-send")
-            .arg(format!($fmt, $($arg,)*))
-            .spawn()
-            .unwrap();
-    };
-);
-
 /// kick off an external program as part of a key/mouse binding.
 /// explicitly redirects stderr to /dev/null
 #[macro_export]
@@ -23,7 +8,7 @@ macro_rules! run_external(
     ($cmd:tt) => {
         {
             Box::new(move |_: &mut $crate::manager::WindowManager| {
-                $crate::helpers::spawn($cmd);
+                $crate::helpers::spawn($cmd)
             }) as $crate::data_types::FireAndForget
         }
     };
@@ -35,12 +20,14 @@ macro_rules! run_internal(
     ($func:ident) => {
         Box::new(|wm: &mut $crate::manager::WindowManager| {
             wm.$func();
+            None
         })
     };
 
     ($func:ident, $($arg:tt),+) => {
         Box::new(move |wm: &mut $crate::manager::WindowManager| {
             wm.$func($($arg),+);
+            None
         })
     };
 );


### PR DESCRIPTION
fixes #6 

rather than ignore SIGCHILD (implicitly, resulting in zombies or explicitly via libc) we now require **FireAndForget** to return an _Option<Child>_ for tracking the spawned process. This will be **try_wait**-ed after processing each event from the event loop until it exits.