### PR TITLE
Issue 1/multi monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ git repo for latest changes.
 ![screenshot](screenshot.png)
 
 ### Current project status
+While the project is still in its early stages, please expect there to be
+multiple breaking changes as the public API stabilises. The example config file
+will always be kept up to date so please refer to that for updating to newer
+versions published to cargo.
+
 If you don't mind a bare bones (_really_ bare bones) window manager then you can
 take penrose for a spin using the config in the `example` directory. You will
 need to update the keybindings to launch your preferred terminal emulator and
 program launcher and may want to adjust the floating window classes to handle
 some additional programs.
+
 
 #### Current functionality
 - partial EWMH support (active window/desktop, number of desktops, desktop

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -175,6 +175,10 @@ impl<T> Ring<T> {
         wrap_back || wrap_forward
     }
 
+    pub fn focused_index(&mut self) -> usize {
+        self.focused
+    }
+
     pub fn focused(&self) -> Option<&T> {
         self.elements.get(self.focused)
     }
@@ -211,6 +215,11 @@ impl<T> Ring<T> {
                 }
             }
         }
+    }
+
+    pub fn focus_nth(&mut self, n: usize) -> Option<&T> {
+        self.focused = n;
+        self.focused()
     }
 
     pub fn cycle_focus(&mut self, direction: Direction) -> Option<&T> {

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -21,6 +21,19 @@ pub type CodeMap = HashMap<String, u8>;
 /// An X window ID
 pub type WinId = u32;
 
+/// An x,y coordinate pair
+#[derive(Debug, Copy, Clone)]
+pub struct Point {
+    pub x: u32,
+    pub y: u32,
+}
+
+impl Point {
+    pub fn new(x: u32, y: u32) -> Point {
+        Point { x, y }
+    }
+}
+
 /// The main user facing configuration details
 #[derive(Debug)]
 pub struct Config {

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -12,7 +12,9 @@ extern crate penrose;
 
 use penrose::helpers::spawn;
 use penrose::layout::{bottom_stack, paper, side_stack};
-use penrose::{ColorScheme, Config, Layout, LayoutConf, WindowManager, XcbConnection};
+use penrose::{
+    Change, ColorScheme, Config, Direction, Layout, LayoutConf, WindowManager, XcbConnection,
+};
 use simplelog;
 use std::env;
 use std::process::Command;
@@ -92,30 +94,30 @@ fn main() {
         "M-A-m" => run_external!("xrandr --output HDMI-1 --auto --right-of eDP-1 "),
 
         // client management
-        "M-j" => run_internal!(next_client),
-        "M-k" => run_internal!(previous_client),
-        "M-S-j" => run_internal!(drag_client_forward),
-        "M-S-k" => run_internal!(drag_client_backward),
+        "M-j" => run_internal!(cycle_client, Direction::Forward),
+        "M-k" => run_internal!(cycle_client, Direction::Backward),
+        "M-S-j" => run_internal!(drag_client, Direction::Forward),
+        "M-S-k" => run_internal!(drag_client, Direction::Backward),
         "M-S-q" => run_internal!(kill_client),
 
         // workspace management
         "M-Tab" => run_internal!(toggle_workspace),
 
         // Layout & window management
-        "M-grave" => Box::new(move |wm| {
-            wm.next_layout();
+        "M-grave" => Box::new(move |wm: &mut WindowManager| {
+            wm.cycle_layout(Direction::Forward);
             active_layout_as_root_name(wm);
             None
         }),
-        "M-S-grave" => Box::new(move |wm| {
-            wm.previous_layout();
+        "M-S-grave" => Box::new(move |wm: &mut WindowManager| {
+            wm.cycle_layout(Direction::Backward);
             active_layout_as_root_name(wm);
             None
         }),
-        "M-A-Up" => run_internal!(inc_main),
-        "M-A-Down" => run_internal!(dec_main),
-        "M-A-Right" => run_internal!(inc_ratio),
-        "M-A-Left" => run_internal!(dec_ratio),
+        "M-A-Up" => run_internal!(update_max_main, Change::More),
+        "M-A-Down" => run_internal!(update_max_main, Change::Less),
+        "M-A-Right" => run_internal!(update_main_ratio, Change::More),
+        "M-A-Left" => run_internal!(update_main_ratio, Change::Less),
         "M-A-C-Escape" => run_internal!(exit),
         "M-A-Escape" => power_menu;
 

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -105,6 +105,8 @@ fn main() {
         "M-Tab" => run_internal!(toggle_workspace),
         "M-bracketright" => run_internal!(cycle_screen, Forward),
         "M-bracketleft" => run_internal!(cycle_screen, Backward),
+        "M-S-bracketright" => run_internal!(drag_workspace, Forward),
+        "M-S-bracketleft" => run_internal!(drag_workspace, Backward),
 
         // Layout & window management
         "M-grave" => Box::new(move |wm: &mut WindowManager| {

--- a/src/example/main.rs
+++ b/src/example/main.rs
@@ -13,7 +13,8 @@ extern crate penrose;
 use penrose::helpers::spawn;
 use penrose::layout::{bottom_stack, paper, side_stack};
 use penrose::{
-    Change, ColorScheme, Config, Direction, Layout, LayoutConf, WindowManager, XcbConnection,
+    Backward, ColorScheme, Config, Forward, Layout, LayoutConf, Less, More, WindowManager,
+    XcbConnection,
 };
 use simplelog;
 use std::env;
@@ -94,30 +95,32 @@ fn main() {
         "M-A-m" => run_external!("xrandr --output HDMI-1 --auto --right-of eDP-1 "),
 
         // client management
-        "M-j" => run_internal!(cycle_client, Direction::Forward),
-        "M-k" => run_internal!(cycle_client, Direction::Backward),
-        "M-S-j" => run_internal!(drag_client, Direction::Forward),
-        "M-S-k" => run_internal!(drag_client, Direction::Backward),
+        "M-j" => run_internal!(cycle_client, Forward),
+        "M-k" => run_internal!(cycle_client, Backward),
+        "M-S-j" => run_internal!(drag_client, Forward),
+        "M-S-k" => run_internal!(drag_client, Backward),
         "M-S-q" => run_internal!(kill_client),
 
         // workspace management
         "M-Tab" => run_internal!(toggle_workspace),
+        "M-bracketright" => run_internal!(cycle_screen, Forward),
+        "M-bracketleft" => run_internal!(cycle_screen, Backward),
 
         // Layout & window management
         "M-grave" => Box::new(move |wm: &mut WindowManager| {
-            wm.cycle_layout(Direction::Forward);
+            wm.cycle_layout(Forward);
             active_layout_as_root_name(wm);
             None
         }),
         "M-S-grave" => Box::new(move |wm: &mut WindowManager| {
-            wm.cycle_layout(Direction::Backward);
+            wm.cycle_layout(Backward);
             active_layout_as_root_name(wm);
             None
         }),
-        "M-A-Up" => run_internal!(update_max_main, Change::More),
-        "M-A-Down" => run_internal!(update_max_main, Change::Less),
-        "M-A-Right" => run_internal!(update_main_ratio, Change::More),
-        "M-A-Left" => run_internal!(update_main_ratio, Change::Less),
+        "M-A-Up" => run_internal!(update_max_main, More),
+        "M-A-Down" => run_internal!(update_max_main, Less),
+        "M-A-Right" => run_internal!(update_main_ratio, More),
+        "M-A-Left" => run_internal!(update_main_ratio, Less),
         "M-A-C-Escape" => run_internal!(exit),
         "M-A-Escape" => power_menu;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod workspace;
 pub mod xconnection;
 
 // top level re-exports
-pub use data_types::{ColorScheme, Config};
+pub use data_types::{Change, ColorScheme, Config, Direction};
 pub use layout::{Layout, LayoutConf};
 pub use manager::WindowManager;
 pub use xconnection::XcbConnection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod workspace;
 pub mod xconnection;
 
 // top level re-exports
-pub use data_types::{Change, ColorScheme, Config, Direction};
+pub use data_types::{Change::*, ColorScheme, Config, Direction::*};
 pub use layout::{Layout, LayoutConf};
 pub use manager::WindowManager;
 pub use xconnection::XcbConnection;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! run_internal(
         })
     };
 
-    ($func:ident, $($arg:tt),+) => {
+    ($func:ident, $($arg:expr),+) => {
         Box::new(move |wm: &mut $crate::manager::WindowManager| {
             wm.$func($($arg),+);
             None

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -306,7 +306,11 @@ impl<'a> WindowManager<'a> {
         self.focus_workspace(i);
     }
 
-    // TODO: workspace -> other screen
+    pub fn drag_workspace(&mut self, direction: Direction) {
+        let wix = self.active_ws_index();
+        self.cycle_screen(direction);
+        self.focus_workspace(wix); // focus_workspace will pull it to the new screen
+    }
 
     /// Cycle between Clients for the active Workspace
     pub fn cycle_client(&mut self, direction: Direction) {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -268,6 +268,8 @@ impl<'a> WindowManager<'a> {
 
     fn handle_screen_change(&mut self) {
         self.set_screen_from_cursor(self.conn.cursor_position());
+        self.workspaces
+            .focus_nth(self.screens.focused().unwrap().wix);
     }
 
     // fn handle_motion_notify(&mut self, event: &xcb::MotionNotifyEvent) {}

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -308,6 +308,7 @@ impl<'a> WindowManager<'a> {
         self.focus_workspace(i);
     }
 
+    /// Move the currently focused workspace to the next Screen in 'direction'
     pub fn drag_workspace(&mut self, direction: Direction) {
         let wix = self.active_ws_index();
         self.cycle_screen(direction);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,5 +1,5 @@
 //! Information on connected displays
-use crate::data_types::Region;
+use crate::data_types::{Point, Region};
 use xcb;
 use xcb::base::Reply;
 use xcb::ffi::randr::xcb_randr_get_crtc_info_reply_t;
@@ -49,5 +49,12 @@ impl Screen {
         } else {
             &self.true_region
         }
+    }
+
+    pub fn contains(&self, p: Point) -> bool {
+        let (x1, y1, w, h) = self.true_region.values();
+        let (x2, y2) = (x1 + w, x1 + h);
+
+        return p.x >= x1 && p.x < x2 && p.y >= y1 && p.y < y2;
     }
 }

--- a/src/xconnection.rs
+++ b/src/xconnection.rs
@@ -228,6 +228,7 @@ pub trait XConn {
     /// Determine the currently connected CRTCs and return their details
     fn current_outputs(&self) -> Vec<Screen>;
 
+    /// Determine the current (x,y) position of the cursor relative to the root window.
     fn cursor_position(&self) -> Point;
 
     /// Reposition the window identified by 'id' to the specifed region


### PR DESCRIPTION
This adds multi-monitor support along with several new public methods on the window manager:

- *cycle_screen* : move focus between screens, leaving all workspaces where they currently are.
- *cycle_workspace* : cycle between available workspaces on the currently focused screen.
- *drag_workspace* : move the focused workspace to the next screen in the given direction. 

In addition, the methods for performing similar actions on clients (and the methods for updating layout params) have been changed so that the public methods take an argument of the direction/change desired. These existed internally already and were being wrapped to provide specialised versions previously. (Which was a bit pointless).

Focus will follow the mouse pointer and actions that set focus to a new screen will warp the cursor to the center of that screen.