### PR TITLE
issue-15: making hooks traits so that they allow for mutable state.

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -3,16 +3,15 @@ use crate::client::Client;
 use crate::data_types::WinId;
 use crate::manager::WindowManager;
 
-pub type WorkspaceIndex = usize;
-pub type ScreenIndex = usize;
-
 /**
  * Called when a new Client has been created and penrose state has been initialised
  * but before the client has been added to the active Workspace and before any Layouts
  * have been applied.
  * Argument is the newly created Client which can be modified if desired.
  */
-pub type NewClientHook = fn(&mut WindowManager, &mut Client);
+pub trait NewClientHook {
+    fn call(&mut self, manager: &mut WindowManager, client: &mut Client);
+}
 
 /**
  * Called before a Layout is applied to the active Workspace.
@@ -20,25 +19,38 @@ pub type NewClientHook = fn(&mut WindowManager, &mut Client);
  * structures that support indexing) which can be used to fetch references to the active Workspace
  * and Screen.
  */
-pub type LayoutHook = fn(&mut WindowManager, WorkspaceIndex, ScreenIndex);
+pub trait LayoutChangeHook {
+    fn call(&mut self, manager: &mut WindowManager, workspace_index: usize, screen_index: usize);
+}
 
 /**
  * Called after the active Workspace is changed on a Screen.
  * Arguments are indices into the WindowManager workspace array (internal data structure that
  * supports indexing) for the previous and new workspace.
  */
-pub type WorkspaceChangeHook = fn(&mut WindowManager, WorkspaceIndex, WorkspaceIndex);
+pub trait WorkspaceChangeHook {
+    fn call(
+        &mut self,
+        manager: &mut WindowManager,
+        previous_workspace: usize,
+        new_workspace: usize,
+    );
+}
 
 /**
  * Called after focus moves to a new Screen.
  * Argument is a index into the WindowManager screen array (internal data structure that supports
  * indexing) for the new Screen.
  */
-pub type ScreenChangeHook = fn(&mut WindowManager, ScreenIndex);
+pub trait ScreenChangeHook {
+    fn call(&mut self, manager: &mut WindowManager, screen_index: usize);
+}
 
 /**
  * Called after a new Client gains focus.
  * Argument is the focused Client ID which can be used to fetch the internal Client state if
  * needed.
  */
-pub type FocusHook = fn(&mut WindowManager, WinId);
+pub trait FocusChangeHook {
+    fn call(&mut self, manager: &mut WindowManager, id: WinId);
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,6 +1,6 @@
 //! A Workspace is a set of displayed clients and a set of Layouts for arranging them
 use crate::client::Client;
-use crate::data_types::{Change, Direction, Region, ResizeAction, Ring, WinId};
+use crate::data_types::{Change, Direction, Region, ResizeAction, Ring, Selector, WinId};
 use crate::layout::{Layout, LayoutConf};
 use std::collections::HashMap;
 
@@ -62,20 +62,20 @@ impl Workspace {
         }
 
         let prev = self.clients.focused().unwrap().clone();
-        self.clients.focus_by(|c| c == &id);
+        self.clients.focus(Selector::Condition(&|c| c == &id));
         Some(prev)
     }
 
     /// Remove a target client, retaining focus at the same position in the stack.
     /// Returns the removed client if there was one to remove.
     pub fn remove_client(&mut self, id: WinId) -> Option<WinId> {
-        self.clients.remove_by(|c| c == &id)
+        self.clients.remove(Selector::Condition(&|c| c == &id))
     }
 
     /// Remove the currently focused client, keeping focus at the same position in the stack.
     /// Returns the removed client if there was one to remove.
     pub fn remove_focused_client(&mut self) -> Option<WinId> {
-        self.clients.remove_focused()
+        self.clients.remove(Selector::Focused)
     }
 
     /// Run the current layout function, generating a list of resize actions to be

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,53 @@
+use penrose::data_types::{FireAndForget, KeyBindings, KeyCode, Region};
+use penrose::screen::Screen;
+use penrose::{Forward, WindowManager};
+use std::collections::HashMap;
+
+const SCREEN_WIDTH: u32 = 1000;
+const SCREEN_HEIGHT: u32 = 600;
+pub const EXIT_CODE: KeyCode = KeyCode { mask: 0, code: 0 };
+pub const LAYOUT_CHANGE_CODE: KeyCode = KeyCode { mask: 0, code: 1 };
+pub const WORKSPACE_CHANGE_CODE: KeyCode = KeyCode { mask: 0, code: 2 };
+pub const SCREEN_CHANGE_CODE: KeyCode = KeyCode { mask: 0, code: 3 };
+pub const FOCUS_CHANGE_CODE: KeyCode = KeyCode { mask: 0, code: 4 };
+
+pub fn simple_screen(n: u32) -> Screen {
+    let r = Region::new(
+        n * SCREEN_WIDTH,
+        n * SCREEN_HEIGHT,
+        SCREEN_WIDTH,
+        SCREEN_HEIGHT,
+    );
+
+    Screen {
+        true_region: r,
+        effective_region: r,
+        wix: n as usize,
+    }
+}
+
+pub fn exit_bindings() -> KeyBindings {
+    let mut bindings = HashMap::new();
+    bindings.insert(
+        EXIT_CODE,
+        Box::new(|wm: &mut WindowManager| wm.exit()) as FireAndForget,
+    );
+    bindings.insert(
+        LAYOUT_CHANGE_CODE,
+        Box::new(|wm: &mut WindowManager| wm.cycle_layout(Forward)) as FireAndForget,
+    );
+    bindings.insert(
+        WORKSPACE_CHANGE_CODE,
+        Box::new(|wm: &mut WindowManager| wm.focus_workspace(1)) as FireAndForget,
+    );
+    bindings.insert(
+        SCREEN_CHANGE_CODE,
+        Box::new(|wm: &mut WindowManager| wm.cycle_screen(Forward)) as FireAndForget,
+    );
+    bindings.insert(
+        FOCUS_CHANGE_CODE,
+        Box::new(|wm: &mut WindowManager| wm.cycle_client(Forward)) as FireAndForget,
+    );
+
+    bindings
+}

--- a/tests/hook_tests.rs
+++ b/tests/hook_tests.rs
@@ -1,0 +1,142 @@
+use penrose::client::Client;
+use penrose::data_types::WinId;
+use penrose::hooks::*;
+use penrose::xconnection::{MockXConn, XEvent};
+use penrose::{Config, WindowManager};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod common;
+
+macro_rules! hook_test(
+    (
+        expected_calls => $n:expr,
+        $trait:ident,
+        $structname:ident,
+        $name:ident,
+        $testname:ident,
+        $evts:expr,
+        $($t:ty),+
+    ) => {
+        struct $structname {
+            name: &'static str,
+            calls: Rc<RefCell<Vec<String>>>,
+        }
+
+        impl $trait for $structname {
+            fn call(&mut self, _: &mut WindowManager, $(_: $t),+) {
+                self.calls.replace_with(|cs| {
+                    cs.push(format!("{}", self.name));
+                    cs.to_vec()
+                });
+            }
+        }
+
+        #[test]
+        fn $testname() {
+            let calls = Rc::new(RefCell::new(vec![]));
+
+            let hook_1 = $structname {
+                name: "hook_1",
+                calls: Rc::clone(&calls),
+            };
+            let hook_2 = $structname {
+                name: "hook_2",
+                calls: Rc::clone(&calls),
+            };
+
+            let mut config = Config::default();
+            config.$name.push(Box::new(hook_1));
+            config.$name.push(Box::new(hook_2));
+
+            let mut events = $evts.clone();
+            events.push(XEvent::KeyPress { code: common::EXIT_CODE });
+
+            let conn = MockXConn::new(
+                vec![common::simple_screen(0), common::simple_screen(1)],
+                events
+            );
+            let mut wm = WindowManager::init(config, &conn);
+            wm.grab_keys_and_run(common::exit_bindings());
+            drop(wm);
+
+            assert_eq!(
+                Rc::try_unwrap(calls).unwrap().into_inner(),
+                ["hook_1", "hook_2"].repeat($n)
+            );
+        }
+    };
+);
+
+hook_test!(
+    expected_calls => 1,
+    NewClientHook,
+    TestNewClientHook,
+    new_client_hooks,
+    test_new_client_hooks,
+    vec![XEvent::Map {
+        id: 1,
+        ignore: false
+    }],
+    &mut Client
+);
+
+hook_test!(
+    expected_calls => 2, // Initial layout application and then due to the change
+    LayoutChangeHook,
+    TestLayoutHook,
+    layout_hooks,
+    test_layout_hooks,
+    vec![XEvent::KeyPress {
+        code: common::LAYOUT_CHANGE_CODE
+    }],
+    usize,
+    usize
+);
+
+hook_test!(
+    expected_calls => 1,
+    WorkspaceChangeHook,
+    TestWorkspaceChangeHook,
+    workspace_change_hooks,
+    test_workspace_hooks,
+    vec![XEvent::KeyPress {
+        code: common::WORKSPACE_CHANGE_CODE
+    }],
+    usize,
+    usize
+);
+
+hook_test!(
+    expected_calls => 1,
+    ScreenChangeHook,
+    TestScreenChangeHook,
+    screen_change_hooks,
+    test_screen_change_hooks,
+    vec![XEvent::KeyPress {
+        code: common::SCREEN_CHANGE_CODE
+    }],
+    usize
+);
+
+hook_test!(
+    expected_calls => 3, // For each client and then the explicit change
+    FocusChangeHook,
+    TestFocusChangeHook,
+    focus_hooks,
+    test_focus_hooks,
+    vec![
+        XEvent::Map {
+            id: 1,
+            ignore: false
+        },
+        XEvent::Map {
+            id: 2,
+            ignore: false
+        },
+        XEvent::KeyPress {
+            code: common::FOCUS_CHANGE_CODE
+        }
+    ],
+    WinId
+);


### PR DESCRIPTION
Also adding methods for getting ahold of workspaces in hooks and bindings.

Closes #15 and #16  using the new `Selector` based methods. Initial integration tests have been added but more testing is needed before releasing these breaking changes as 0.1.8

This ended up being more of a change than originally wanted as in order for hooks to _actually_ make use of external state they can not be an arbirtrary closure it seems (e.g. **FnMut**), or at least, I couldn't find a way that didn't make setting them up far more cumbersome than implementing a trait.