### PR TITLE
Fixing issue with gen_keybindings and run_internal

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install XCB deps
-      run: sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev
+    - name: Install C deps
+      run: sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -12,8 +12,6 @@ use penrose::{Backward, Config, Forward, Less, More, WindowManager, XcbConnectio
 fn main() {
     let config = Config::default();
     let key_bindings = gen_keybindings! {
-        "M-semicolon" => run_external!("dmenu_run"),
-        "M-Return" => run_external!("st"),
         "M-j" => run_internal!(cycle_client, Forward),
         "M-k" => run_internal!(cycle_client, Backward),
         "M-S-j" => run_internal!(drag_client, Forward),
@@ -30,7 +28,9 @@ fn main() {
         "M-A-Down" => run_internal!(update_max_main, Less),
         "M-A-Right" => run_internal!(update_main_ratio, More),
         "M-A-Left" => run_internal!(update_main_ratio, Less),
-        "M-A-Escape" => run_internal!(exit);
+        "M-A-Escape" => run_internal!(exit),
+        "M-semicolon" => run_external!("dmenu_run"),
+        "M-Return" => run_external!("st");
 
         forall_workspaces: config.workspaces => {
             "M-{}" => focus_workspace,

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -20,13 +20,13 @@ macro_rules! run_internal(
     ($func:ident) => {
         Box::new(|wm: &mut $crate::manager::WindowManager| {
             wm.$func();
-        })
+        }) as $crate::data_types::FireAndForget
     };
 
     ($func:ident, $($arg:expr),+) => {
         Box::new(move |wm: &mut $crate::manager::WindowManager| {
             wm.$func($($arg),+);
-        })
+        }) as $crate::data_types::FireAndForget
     };
 );
 


### PR DESCRIPTION
We were not explicitly casting the Boxed closure returned by
run_internal to FireAndForget, as we were with run_external. When a
run_external binding was provided first, it allowed the compiler to
correctly cast all subsequent closures to FireAndForget: when
run_internal was first, the compiler tried to cast everything to _that_
closure type. I've not added a test for this as the macro relies on
running xmodmap and an X server which is a no-go in CI (or at least I
_think_ it is). The minimal example config has now been updated though
and the builds and runs fine locally.