### PR TITLE
focus_or_spawn action

### DIFF
--- a/src/contrib/actions.rs
+++ b/src/contrib/actions.rs
@@ -37,8 +37,7 @@ pub fn focus_or_spawn(class: String, command: String) -> FireAndForget {
     Box::new(move |wm: &mut WindowManager| {
         let cond = |c: &Client| c.class() == &class;
         let sel = Selector::Condition(&cond);
-        let client = wm.client(&sel);
-        if let Some(client) = client {
+        if let Some(client) = wm.client(&sel) {
             let workspace = client.workspace();
             wm.focus_workspace(&Selector::Index(workspace));
         } else {

--- a/src/contrib/actions.rs
+++ b/src/contrib/actions.rs
@@ -1,7 +1,8 @@
 //! Additional helper functions and actions for use with penrose.
 use crate::{
-    core::{Layout, WindowManager, Workspace},
+    core::{Layout, WindowManager, Workspace, Client},
     data_types::{FireAndForget, Selector},
+    helpers::spawn,
 };
 
 /**
@@ -23,5 +24,25 @@ pub fn create_or_switch_to_workspace(
             wm.push_workspace(Workspace::new(name, layouts.clone()))
         }
         wm.focus_workspace(&sel);
+    })
+}
+
+/**
+ * Focus a Client with the given class as WM_CLASS or spawn the program with
+ * the given command if no such Client exists. This is useful for key bindings 
+ * that are based on the program you want to work with rather than having to 
+ * remember where things are running.
+ */
+pub fn focus_or_spawn(class: String, command: String) -> FireAndForget {
+    Box::new(move |wm: &mut WindowManager| {
+        let cond = |c: &Client| c.class() == &class;
+        let sel = Selector::Condition(&cond);
+        let client = wm.client(&sel);
+        if let Some(client) = client {
+            let workspace = client.workspace();
+            wm.focus_workspace(&Selector::Index(workspace));
+        } else {
+            spawn(&command);
+        }
     })
 }


### PR DESCRIPTION
I've implemented #34 too. I wasn't sure whether to pass Strings or functions as arguments. Maybe passing functions would make sense if you would use dmenu or rofi to switch between windows, but rofi already implements this feature anyway. For binding keys to specific programs it's probably easier to pass Strings, because non-closure functions can't capture environment and you might want to pass some variable like `my_file_manager`.