### PR TITLE
handle mouse events & floating windows

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -14,7 +14,6 @@ pub struct Client {
     wm_class: String,
     workspace: usize,
     // state flags
-    floating: bool,
     pub(crate) fullscreen: bool,
     pub(crate) mapped: bool,
     pub(crate) wm_managed: bool,
@@ -27,14 +26,12 @@ impl Client {
         wm_name: String,
         wm_class: String,
         workspace: usize,
-        floating: bool,
     ) -> Client {
         Client {
             id,
             wm_name,
             wm_class,
             workspace,
-            floating: floating,
             fullscreen: false,
             mapped: false,
             wm_managed: true,


### PR DESCRIPTION
This is the beginnings of an implementation of floating windows with mouse controls i3wm style (issue #36).

## Testing / proposed controls
- `toggle_workspace_focus` function toggles focus for active workspace between tiled and floating if possible, empty floating layer forces focus to tiled
- `toggle_client_floating` moves focused window between tiled and floating layers of the active workspace, it should be possible to use other selectors too, just not implemented yet
- `showhide_floating` function (TODO)
- `mod+leftdrag` -- move floating window around
- `mod+rightdrag` -- resize floating window
- `mod+middleclick` -- close any window

Sorry I changed the modifier from Mod4 to Alt since I don't have Mod4 on my keyboard, it will have to be configurable in the end anyway.

## Tasks mostly in the order I want to work on them
- [x]  split tiled and floating layers in `Workspace`
- [x] allow switching which layer is in focus
- [ ] new windows should be probably always added to the tiling layer (unless they're in the auto-floating list) and should then change the focused layer automatically
- [ ] raise the focused window in floating layer
- [ ] configure window moved to floating layer to some reasonable size (EWHM hints?) and center it
  - [ ] add some nice stacking algorigthm
- [ ] implement dragging windows
- [ ] implement resizing windows
- [ ] implement cancelation for dragging/resizing when interrupted by other events
- [ ] add a function for showing/hiding the floating layer on particular workspace
- [ ] maybe unify the implementations of `Workspace` and `ScratchPad` to reduce code and also add the option to have more windows per scratchpad

I probably forgot something so I'll continually add/expand the tasks as I go, please mention anything you think I should also do as a part of this PR.

Also any bikeshedding (better names) is welcome but I'd like to leave it until after the implementation is down.