### PR TITLE
RGBA support for draw module

### DIFF
--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -8,12 +8,12 @@ const PROFONT: &'static str = "ProFont For Powerline";
 const FIRA: &'static str = "Fira Code";
 const SERIF: &'static str = "Serif";
 
-const BLACK: u32 = 0x282828;
-const GREY: u32 = 0x3c3836;
-const WHITE: u32 = 0xebdbb2;
-const PURPLE: u32 = 0xb16286;
-const BLUE: u32 = 0x458588;
-const RED: u32 = 0xcc241d;
+const BLACK: u32 = 0x282828ff;
+const GREY: u32 = 0x3c3836ff;
+const WHITE: u32 = 0xebdbb2ff;
+const PURPLE: u32 = 0xb16286ff;
+const BLUE: u32 = 0x458588ff;
+const RED: u32 = 0xcc241dff;
 
 fn main() -> Result<()> {
     bar_draw()?;

--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -160,10 +160,22 @@ pub(crate) mod xcb_util {
         h: u16,
     ) -> Result<u32> {
         let id = conn.generate_id();
+        let colormap = conn.generate_id();
+
+        let depth = get_depth(screen)?;
+        let visual = get_visual_type(&depth)?;
+
+        xcb::xproto::create_colormap(
+            &conn,
+            xcb::COLORMAP_ALLOC_NONE as u8,
+            colormap,
+            screen.root(),
+            visual.visual_id(), 
+        );
 
         xcb::create_window(
             &conn,
-            xcb::COPY_FROM_PARENT as u8,
+            depth.depth(),
             id,
             screen.root(),
             x,
@@ -172,9 +184,10 @@ pub(crate) mod xcb_util {
             h,
             0,
             xcb::WINDOW_CLASS_INPUT_OUTPUT as u16,
-            0,
+            visual.visual_id(),
             &[
-                (xcb::CW_BACK_PIXEL, screen.black_pixel()),
+                (xcb::CW_BORDER_PIXEL, screen.black_pixel()),
+                (xcb::CW_COLORMAP, colormap),
                 (xcb::CW_EVENT_MASK, xcb::EVENT_MASK_EXPOSURE),
             ],
         );
@@ -195,16 +208,20 @@ pub(crate) mod xcb_util {
         Ok(id)
     }
 
-    pub fn get_visual_type(
-        conn: &xcb::Connection,
-        screen: &xcb::Screen,
+    pub fn get_depth<'a>(
+        screen: &'a xcb::Screen,
+    ) -> Result<xcb::Depth<'a>> {
+        screen.allowed_depths()
+            .max_by(|x, y| x.depth().cmp(&y.depth()))
+            .ok_or_else(|| anyhow!("unable to get screen depth"))
+    }
+
+    pub fn get_visual_type<'a>(
+        depth: &xcb::Depth<'a>,
     ) -> Result<xcb::Visualtype> {
-        conn.get_setup()
-            .roots()
-            .flat_map(|r| r.allowed_depths())
-            .flat_map(|d| d.visuals())
-            .find(|v| v.visual_id() == screen.root_visual())
-            .ok_or_else(|| anyhow!("unable to get screen visual type"))
+        depth.visuals()
+            .find(|v| v.class() == xcb::VISUAL_CLASS_TRUE_COLOR as u8)
+            .ok_or_else(|| anyhow!("unable to get visual type"))
     }
 
     pub fn screen_sizes(conn: &xcb::Connection) -> Result<Vec<Region>> {

--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -170,7 +170,7 @@ pub(crate) mod xcb_util {
             xcb::COLORMAP_ALLOC_NONE as u8,
             colormap,
             screen.root(),
-            visual.visual_id(), 
+            visual.visual_id(),
         );
 
         xcb::create_window(
@@ -208,18 +208,16 @@ pub(crate) mod xcb_util {
         Ok(id)
     }
 
-    pub fn get_depth<'a>(
-        screen: &'a xcb::Screen,
-    ) -> Result<xcb::Depth<'a>> {
-        screen.allowed_depths()
+    pub fn get_depth<'a>(screen: &'a xcb::Screen) -> Result<xcb::Depth<'a>> {
+        screen
+            .allowed_depths()
             .max_by(|x, y| x.depth().cmp(&y.depth()))
             .ok_or_else(|| anyhow!("unable to get screen depth"))
     }
 
-    pub fn get_visual_type<'a>(
-        depth: &xcb::Depth<'a>,
-    ) -> Result<xcb::Visualtype> {
-        depth.visuals()
+    pub fn get_visual_type<'a>(depth: &xcb::Depth<'a>) -> Result<xcb::Visualtype> {
+        depth
+            .visuals()
             .find(|v| v.class() == xcb::VISUAL_CLASS_TRUE_COLOR as u8)
             .ok_or_else(|| anyhow!("unable to get visual type"))
     }

--- a/src/draw/bar/bar.rs
+++ b/src/draw/bar/bar.rs
@@ -82,6 +82,8 @@ impl<Ctx: DrawContext> StatusBar<Ctx> {
             let screen_has_focus = self.active_screen == i;
             let mut ctx = self.drw.context_for(id)?;
 
+            ctx.clear();
+
             ctx.color(&self.bg);
             ctx.rectangle(0.0, 0.0, w, self.h as f64);
 

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -32,7 +32,9 @@ mod inner {
         h: i32,
     ) -> Result<(u32, XCBSurface)> {
         let id = xcb_util::create_window(conn, screen, wt.as_ewmh_str(), x, y, w as u16, h as u16)?;
-        let mut visualtype = xcb_util::get_visual_type(&conn, screen)?;
+
+        let depth = xcb_util::get_depth(screen)?;
+        let mut visualtype = xcb_util::get_visual_type(&depth)?;
 
         let surface = unsafe {
             let conn_ptr = conn.get_raw_conn() as *mut cairo_sys::xcb_connection_t;
@@ -216,6 +218,8 @@ mod inner {
         fn font(&mut self, font_name: &str, point_size: i32) -> Result<()>;
         /// Set the color used for subsequent drawing operations
         fn color(&mut self, color: &Color);
+        /// Clears the context
+        fn clear(&mut self);
         /// Translate this context by (dx, dy) from its current position
         fn translate(&self, dx: f64, dy: f64);
         /// Set the x offset for this context absolutely
@@ -341,8 +345,15 @@ mod inner {
         }
 
         fn color(&mut self, color: &Color) {
-            let (r, g, b) = color.rgb();
-            self.ctx.set_source_rgb(r, g, b);
+            let (r, g, b, a) = color.rgba();
+            self.ctx.set_source_rgba(r, g, b, a);
+        }
+
+        fn clear(&mut self) {
+            self.ctx.save();
+            self.ctx.set_operator(cairo::Operator::Clear);
+            self.ctx.paint();
+            self.ctx.restore();
         }
 
         fn translate(&self, dx: f64, dy: f64) {

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -103,6 +103,62 @@ mod inner {
             Self { r, g, b, a: 1.0 }
         }
 
+        /// Create a new Color from a hex encoded u32: 0xRRGGBB or 0xRRGGBBAA
+        pub fn new_from_hex(hex: u32) -> Self {
+            let a = if hex > 0x00FFFFFF { (hex >> 24 & 0xFF) as f64 / 255.0 } else { 1.0 };
+            let r = (hex >> 16 & 0xFF) as f64 / 255.0;
+            let g = (hex >> 8 & 0xFF) as f64 / 255.0;
+            let b = (hex >> 0 & 0xFF) as f64 / 255.0;
+
+            Self { r, g, b, a }
+            
+            /*
+            let s = if (hex & 0x00FFFFFF) != 0 && (hex & 0xFF000000) == 0 {
+                println!("rgb");
+                8
+            } else { 
+                println!("rgba");
+                0 
+            };
+
+            // If no alpha value was supplied, everything must be shifted 8 bits and
+            // the alpha value should be set to 1.0
+            //
+            // 0x00RRGGBB -> 0xRRGGBBFF
+            //
+            // For example, when extracting 'r', we should only shift it 16 bits instead of 24
+            // bits when an alpha value is supplied. 
+            let r = (hex >> 24 - s & 0xFF) as f64 / 255.0;
+            let g = (hex >> 16 - s & 0xFF) as f64 / 255.0;
+            let b = (hex >> 8 - s & 0xFF) as f64 / 255.0;
+            let a = if s == 0 { (hex >> 0 & 0xFF) as f64 / 255.0 } else { 1.0 };
+
+            Self { r, g, b, a }
+            */
+
+            /*
+            let bytes = hex.to_le_bytes();
+            let byte_iter = bytes.iter();
+
+            println!("{:#x} -> {:?}", hex, bytes);
+
+            if byte_iter.clone().take(3).any(|b| *b != 0) && *byte_iter.clone().last().unwrap() == 0 {
+                println!("rgb");
+                let floats: Vec<f64> = byte_iter.clone()
+                    .map(|n| *n as f64 / 255.0)
+                    .collect();
+                let (r, g, b, a) = (floats[2], floats[1], floats[0], 1.0);
+                Self { r, g, b, a }
+            } else {
+                println!("rgba");
+                let floats: Vec<f64> = byte_iter.clone()
+                    .map(|n| *n as f64 / 255.0)
+                    .collect();
+                let (r, g, b, a) = (floats[2], floats[1], floats[0], floats[3]);
+                Self { r, g, b, a }
+            }*/
+        }
+
         /// The RGB information of this color as 0.0-1.0 range floats representing
         /// proportions of 255 for each of R, G, B
         pub fn rgb(&self) -> (f64, f64, f64) {
@@ -118,7 +174,7 @@ mod inner {
 
     impl From<u32> for Color {
         fn from(hex: u32) -> Self {
-            Self::new_from_hex_rgb(hex)
+            Self::new_from_hex(hex)
         }
     }
 
@@ -412,5 +468,28 @@ mod inner {
         fn flush(&self) {
             self.ctx.get_target().flush();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_from_hex_rgba() {
+        //assert_eq!(Color::from(0x00000000), Color::from((0.0, 0.0, 0.0, 0.0)));
+        assert_eq!(Color::from(0xFF00FFFF), Color::from((0.0, 1.0, 1.0, 1.0)));
+        assert_eq!(Color::from(0xFFFFFFFF), Color::from((1.0, 1.0, 1.0, 1.0)));
+        assert_eq!(Color::from(0xFFFF00FF), Color::from((1.0, 0.0, 1.0, 1.0)));
+        assert_eq!(Color::from(0xFFFF0000), Color::from((1.0, 0.0, 0.0, 1.0)));
+        assert_eq!(Color::from(0xFF000000), Color::from((0.0, 0.0, 0.0, 1.0)));
+    }
+
+    #[test]
+    fn test_color_from_hex_rgb() {
+        assert_eq!(Color::from(0x000000), Color::from((0.0, 0.0, 0.0, 1.0)));
+        assert_eq!(Color::from(0xFFFFFF), Color::from((1.0, 1.0, 1.0, 1.0)));
+        assert_eq!(Color::from(0xFF00FF), Color::from((1.0, 0.0, 1.0, 1.0)));
+        assert_eq!(Color::from(0x0000FF), Color::from((0.0, 0.0, 1.0, 1.0)));
     }
 }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -82,7 +82,8 @@ mod inner {
     impl Color {
         /// Create a new Color from a hex encoded u32: 0xRRGGBB or 0xRRGGBBAA
         pub fn new_from_hex(hex: u32) -> Self {
-            let floats: Vec<f64> = hex.to_be_bytes()
+            let floats: Vec<f64> = hex
+                .to_be_bytes()
                 .iter()
                 .map(|n| *n as f64 / 255.0)
                 .collect();
@@ -136,19 +137,17 @@ mod inner {
         type Error = anyhow::Error;
 
         fn try_from(s: &str) -> Result<Color> {
-            let hex = u32::from_str_radix(
-                s.strip_prefix('#').unwrap_or_else(|| &s),
-                16,
-            )?;
-
-            println!("{:#x}", hex);
+            let hex = u32::from_str_radix(s.strip_prefix('#').unwrap_or_else(|| &s), 16)?;
 
             if s.len() == 7 {
                 Ok(Self::new_from_hex((hex << 8) + 0xFF))
             } else if s.len() == 9 {
                 Ok(Self::new_from_hex(hex))
             } else {
-                Err(anyhow!("failed to parse {} into a Color, invalid length", &s))
+                Err(anyhow!(
+                    "failed to parse {} into a Color, invalid length",
+                    &s
+                ))
             }
         }
     }
@@ -423,13 +422,25 @@ mod tests {
 
     #[test]
     fn test_color_from_str_rgb() {
-        assert_eq!(Color::try_from("#000000").unwrap(), Color::from((0.0, 0.0, 0.0, 1.0)));
-        assert_eq!(Color::try_from("#FF00FF").unwrap(), Color::from((1.0, 0.0, 1.0, 1.0)));
+        assert_eq!(
+            Color::try_from("#000000").unwrap(),
+            Color::from((0.0, 0.0, 0.0, 1.0))
+        );
+        assert_eq!(
+            Color::try_from("#FF00FF").unwrap(),
+            Color::from((1.0, 0.0, 1.0, 1.0))
+        );
     }
 
     #[test]
     fn test_color_from_str_rgba() {
-        assert_eq!(Color::try_from("#000000FF").unwrap(), Color::from((0.0, 0.0, 0.0, 1.0)));
-        assert_eq!(Color::try_from("#FF00FF00").unwrap(), Color::from((1.0, 0.0, 1.0, 0.0)));
+        assert_eq!(
+            Color::try_from("#000000FF").unwrap(),
+            Color::from((0.0, 0.0, 0.0, 1.0))
+        );
+        assert_eq!(
+            Color::try_from("#FF00FF00").unwrap(),
+            Color::from((1.0, 0.0, 1.0, 0.0))
+        );
     }
 }


### PR DESCRIPTION
Implements RGBA colors and 32-bit window depth for the draw module. Can be used to create transparent status bars, see #53.

Breaking change: all hexadecimal colors that get converted into a `Color` struct are interpreted as `rgba`. Colors used in `core` are not affected and remain `rgb`.