### PR TITLE
#52 fixing issue with follow_focus layouts breaking with scratchpads enabled

### DIFF
--- a/src/contrib/extensions/scratchpad.rs
+++ b/src/contrib/extensions/scratchpad.rs
@@ -81,12 +81,11 @@ impl Scratchpad {
         };
 
         if *self.visible.borrow() {
-            wm.hide_client(id);
             self.visible.replace(false);
+            wm.hide_client(id);
         } else {
-            wm.show_client(id);
-            wm.layout_screen(wm.active_screen_index()); // caught by layout_change
             self.visible.replace(true);
+            wm.layout_screen(wm.active_screen_index()); // caught by layout_change
         }
     }
 }
@@ -117,13 +116,16 @@ impl Hook for Scratchpad {
         match *self.client.borrow() {
             None => return, // no active scratchpad client
             Some(id) => {
-                if let Some(region) = wm.screen_size(screen_index) {
-                    let (sx, sy, sw, sh) = region.values();
-                    let w = (sw as f32 * self.w) as u32;
-                    let h = (sh as f32 * self.h) as u32;
-                    let x = sx + (sw - w) / 2;
-                    let y = sy + (sh - h) / 2;
-                    wm.position_client(id, Region::new(x, y, w, h));
+                if *self.visible.borrow() {
+                    if let Some(region) = wm.screen_size(screen_index) {
+                        let (sx, sy, sw, sh) = region.values();
+                        let w = (sw as f32 * self.w) as u32;
+                        let h = (sh as f32 * self.h) as u32;
+                        let x = sx + (sw - w) / 2;
+                        let y = sy + (sh - h) / 2;
+                        wm.position_client(id, Region::new(x, y, w, h));
+                    }
+                    wm.show_client(id);
                 }
             }
         }

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -227,8 +227,8 @@ impl<'a> WindowManager<'a> {
     }
 
     fn client_gained_focus(&mut self, id: WinId) {
-        self.focused_client()
-            .map(|c| self.client_lost_focus(c.id()));
+        let prev_focused = self.focused_client().map(|c| c.id());
+        prev_focused.map(|id| self.client_lost_focus(id));
 
         self.conn.set_client_border_color(id, self.focused_border);
         self.conn.focus_client(id);
@@ -236,7 +236,8 @@ impl<'a> WindowManager<'a> {
         if let Some(wix) = self.workspace_index_for_client(id) {
             if let Some(ws) = self.workspaces.get_mut(wix) {
                 ws.focus_client(id);
-                if ws.layout_conf().follow_focus {
+                let prev_was_in_ws = prev_focused.map_or(false, |id| ws.clients().contains(&id));
+                if ws.layout_conf().follow_focus && prev_was_in_ws {
                     self.apply_layout(wix);
                 }
             }

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -84,8 +84,6 @@ const PROP_MODE_REPLACE: u8 = xcb::PROP_MODE_REPLACE as u8;
 const ATOM_WINDOW: u32 = xcb::xproto::ATOM_WINDOW;
 const ATOM_ATOM: u32 = xcb::xproto::ATOM_ATOM;
 const ATOM_CARDINAL: u32 = xcb::xproto::ATOM_CARDINAL;
-const STACK_ABOVE: u32 = xcb::STACK_MODE_ABOVE as u32;
-const STACK_MODE: u16 = xcb::CONFIG_WINDOW_STACK_MODE as u16;
 const WIN_BORDER: u16 = xcb::CONFIG_WINDOW_BORDER_WIDTH as u16;
 const WIN_HEIGHT: u16 = xcb::CONFIG_WINDOW_HEIGHT as u16;
 const WIN_WIDTH: u16 = xcb::CONFIG_WINDOW_WIDTH as u16;
@@ -743,7 +741,6 @@ impl XConn for XcbConnection {
                 (WIN_WIDTH, w),
                 (WIN_HEIGHT, h),
                 (WIN_BORDER, border),
-                (STACK_MODE, STACK_ABOVE),
             ],
         );
     }


### PR DESCRIPTION
addresses #52 

Tested locally under Xephyr using the paper layout and scratchpads. I've tweaked the way that the scratchpad triggers it's window repositioning calls so that it only runs when it is visible, but the actual fix is to no longer map windows with `STACK_ABOVE` set. This was resulting in new enter notify events being sent and retriggering the layout application. I suspect that this would have been an issue for any layout that wanted to set overlapping windows as well. Come to think of it, I think I hit a version of this with an earlier attempt at implementing the paper layout so it might be possible to go back to that implementation now, which allowed the windows to overlap under one another rather than resizing them explicitly.