### PR TITLE
Ignore numlock modifier

### DIFF
--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -42,7 +42,7 @@ fn bar_draw() -> Result<()> {
     )?;
 
     let config = Config::default();
-    let conn = XcbConnection::new().unwrap();
+    let conn = XcbConnection::new(None).unwrap();
     let mut wm = WindowManager::init(config, &conn);
     bar.startup(&mut wm); // ensure widgets are initialised correctly
 

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -10,6 +10,7 @@ use penrose::contrib::actions::create_or_switch_to_workspace;
 use penrose::contrib::extensions::Scratchpad;
 use penrose::contrib::hooks::{DefaultWorkspace, LayoutSymbolAsRootName, RemoveEmptyWorkspaces};
 use penrose::contrib::layouts::paper;
+use penrose::helpers::modifiers_from_xmodmap;
 
 use simplelog::{LevelFilter, SimpleLogger};
 use std::env;
@@ -97,7 +98,8 @@ fn main() {
         }
     };
 
-    let conn = XcbConnection::new().unwrap();
+    let modifier_map = modifiers_from_xmodmap();
+    let conn = XcbConnection::new(modifier_map.get("Num_Lock").map(|m| *m)).unwrap();
     let mut wm = WindowManager::init(config, &conn);
     wm.grab_keys_and_run(key_bindings);
 }

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -38,7 +38,7 @@ fn main() {
         }
     };
 
-    let conn = XcbConnection::new().unwrap();
+    let conn = XcbConnection::new(None).unwrap();
     let mut wm = WindowManager::init(config, &conn);
     wm.grab_keys_and_run(key_bindings);
 }

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -17,6 +17,7 @@ use penrose::{
         layouts::paper,
     },
     data_types::Selector,
+    helpers::modifiers_from_xmodmap,
     hooks::Hook,
     layout::{bottom_stack, side_stack, Layout, LayoutConf},
     Backward, Config, Forward, Less, More, WindowManager, XcbConnection,
@@ -170,7 +171,13 @@ fn main() {
     // reference implementation of this trait that uses the XCB library to communicate with the X
     // server. You are free to provide your own implementation if you wish, see xconnection.rs for
     // details of the required methods and expected behaviour.
-    let conn = XcbConnection::new().unwrap();
+    let mut conn = XcbConnection::new().unwrap();
+
+    let modifier_map = modifiers_from_xmodmap();
+
+    if let Some(&numlock_mask) = modifier_map.get("Num_Lock") {
+        conn.set_numlock_mask(numlock_mask);
+    }
 
     // Create the WindowManager instance with the config we have built and a connection to the X
     // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -167,17 +167,13 @@ fn main() {
         }
     };
 
+    let modifier_map = modifiers_from_xmodmap();
+
     // The underlying connection to the X server is handled as a trait: XConn. XcbConnection is the
     // reference implementation of this trait that uses the XCB library to communicate with the X
     // server. You are free to provide your own implementation if you wish, see xconnection.rs for
     // details of the required methods and expected behaviour.
-    let mut conn = XcbConnection::new().unwrap();
-
-    let modifier_map = modifiers_from_xmodmap();
-
-    if let Some(&numlock_mask) = modifier_map.get("Num_Lock") {
-        conn.set_numlock_mask(numlock_mask);
-    }
+    let conn = XcbConnection::new(modifier_map.get("Num_Lock").map(|m| *m)).unwrap();
 
     // Create the WindowManager instance with the config we have built and a connection to the X
     // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions

--- a/src/core/data_types.rs
+++ b/src/core/data_types.rs
@@ -182,9 +182,9 @@ pub struct KeyCode {
 
 impl KeyCode {
     /// Build a new KeyCode from an XCB KeyPressEvent
-    pub fn from_key_press(k: &xcb::KeyPressEvent) -> KeyCode {
+    pub fn from_key_press(k: &xcb::KeyPressEvent, ignored_mask: u16) -> KeyCode {
         KeyCode {
-            mask: k.state(),
+            mask: k.state() & !ignored_mask,
             code: k.detail(),
         }
     }

--- a/src/core/data_types.rs
+++ b/src/core/data_types.rs
@@ -24,6 +24,9 @@ pub type ResizeAction = (WinId, Option<Region>);
 /// Map xmodmap key names to their X key code so that we can bind them by name
 pub type CodeMap = HashMap<String, u8>;
 
+/// Map xmodmap key names to their modifier mask
+pub type ModMap = HashMap<String, u16>;
+
 /// An X window ID
 pub type WinId = u32;
 
@@ -190,9 +193,8 @@ impl KeyCode {
     }
 
     /// Removes the given mask from the modifier mask
-    pub fn ignore_modifiers(&mut self, modifier_masks: &[u16]) {
-        let mask = modifier_masks.iter().max().unwrap(); // The largest number is the combination of all masks
-        self.mask = self.mask & !mask;
+    pub fn ignore_modifiers(&mut self, modifier_mask: u16) {
+        self.mask = self.mask & !modifier_mask;
     }
 }
 

--- a/src/core/data_types.rs
+++ b/src/core/data_types.rs
@@ -182,11 +182,17 @@ pub struct KeyCode {
 
 impl KeyCode {
     /// Build a new KeyCode from an XCB KeyPressEvent
-    pub fn from_key_press(k: &xcb::KeyPressEvent, ignored_mask: u16) -> KeyCode {
+    pub fn from_key_press(k: &xcb::KeyPressEvent) -> KeyCode {
         KeyCode {
-            mask: k.state() & !ignored_mask,
+            mask: k.state(),
             code: k.detail(),
         }
+    }
+
+    /// Removes the given mask from the modifier mask
+    pub fn ignore_modifiers(&mut self, modifier_masks: &[u16]) {
+        let mask = modifier_masks.iter().max().unwrap(); // The largest number is the combination of all masks
+        self.mask = self.mask & !mask;
     }
 }
 

--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -1,6 +1,6 @@
 //! Utility functions for use in other parts of penrose
 use crate::{
-    data_types::{CodeMap, KeyCode},
+    data_types::{CodeMap, KeyCode, ModMap},
     Result,
 };
 
@@ -95,88 +95,46 @@ pub fn keycodes_from_xmodmap() -> CodeMap {
 }
 
 /**
- * Run the xmodmap command to dump a list of mod masks from the given
- * key names.
+ * Run the xmodmap command to dump the system modifier key table
  */
-pub fn modifiers_from_xmodmap(key_names: &[&str]) -> Vec<u16> {
+pub fn modifiers_from_xmodmap() -> ModMap {
+    let mut mod_map = ModMap::new();
+
     match Command::new("xmodmap").arg("-pm").output() {
         Err(e) => panic!("unable to fetch modifiers via xmodmap: {}", e),
         Ok(o) => match String::from_utf8(o.stdout) {
             Err(e) => panic!("invalid utf8 from xmodmap: {}", e),
-            Ok(s) => s
-                .lines()
-                .filter_map(|l| {
-                    // <mod name> = <key name (keycode) ...>
-                    if key_names.iter().any(|key| l.contains(key)) {
-                        let mut words = l.split_whitespace();
-                        words.next().map(|name| match name {
-                            "shift" => xcb::MOD_MASK_SHIFT,
-                            "lock" => xcb::MOD_MASK_LOCK,
-                            "control" => xcb::MOD_MASK_CONTROL,
-                            "mod1" => xcb::MOD_MASK_1,
-                            "mod2" => xcb::MOD_MASK_2,
-                            "mod3" => xcb::MOD_MASK_3,
-                            "mod4" => xcb::MOD_MASK_4,
-                            "mod5" => xcb::MOD_MASK_5,
-                            _ => panic!("unknown modifier: {}", name),
-                        } as u16)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<u16>>(),
+            Ok(s) => s.lines().skip(2).for_each(|l| {
+                // words == <mod name> <keyname (keycode), ...>
+                let mut words = l.split_whitespace();
+                let mask = words.next().map(|name| match name {
+                    "shift" => xcb::MOD_MASK_SHIFT,
+                    "lock" => xcb::MOD_MASK_LOCK,
+                    "control" => xcb::MOD_MASK_CONTROL,
+                    "mod1" => xcb::MOD_MASK_1,
+                    "mod2" => xcb::MOD_MASK_2,
+                    "mod3" => xcb::MOD_MASK_3,
+                    "mod4" => xcb::MOD_MASK_4,
+                    "mod5" => xcb::MOD_MASK_5,
+                    _ => panic!("unknown modifier: {}", name),
+                } as u16);
+
+                if let Some(mask) = mask {
+                    // remainder == <keyname(keycode), ...>
+                    let remainder = words.collect::<String>();
+
+                    remainder.split(',').for_each(|key| {
+                        // key == <keyname(keycode)>
+                        if let Some(name) = key.split('(').next() {
+                            mod_map.insert(name.into(), mask);
+                        }
+                    });
+                }
+            }),
         },
     }
-}
 
-/**
- * All possible masks that should be ignored.
- *
- * Calls 'modifiers_from_xmodmap' to get all individual masks and computes the power set 
- * with each element reduced to a single mask with the binary 'or' operator.
- */
-pub fn ignored_modifier_masks(key_names: &[&str]) -> Vec<u16> {
-    let modifiers = modifiers_from_xmodmap(key_names);
-
-    (0..((2 as u32).pow(modifiers.len() as u32)))
-        .into_iter()
-        .map(|c| {
-            modifiers
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| c & (1 << i) > 0)
-                .fold(0, |acc, (_, m)| acc | m)
-        })
-        .collect()
-}
-
-// Tests will probably have to be removed, because they rely on specific modmap configuration
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn ignored_modifiers() {
-        let mut result = modifiers_from_xmodmap(&["Num_Lock", "Caps_Lock"]);
-        result.sort();
-        let mut expected = vec![xcb::MOD_MASK_2 as u16, xcb::MOD_MASK_LOCK as u16];
-        expected.sort();
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn ignored_mod_masks() {
-        let mut result = ignored_modifier_masks(&["Num_Lock", "Caps_Lock"]);
-        result.sort();
-        let mut expected = vec![
-            0,
-            xcb::MOD_MASK_2 as u16,
-            xcb::MOD_MASK_LOCK as u16,
-            (xcb::MOD_MASK_2 | xcb::MOD_MASK_LOCK) as u16,
-        ];
-        expected.sort();
-        assert_eq!(result, expected);
-    }
+    mod_map
 }
 
 /**

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -464,7 +464,7 @@ pub struct XcbConnection {
 
 impl XcbConnection {
     /// Establish a new connection to the running X server. Fails if unable to connect
-    pub fn new() -> Result<XcbConnection> {
+    pub fn new(numlock_mask: Option<u16>) -> Result<XcbConnection> {
         let (conn, _) = match xcb::Connection::connect(None) {
             Err(e) => return Err(anyhow!("unable to establish connection to X server: {}", e)),
             Ok(conn) => conn,
@@ -528,13 +528,8 @@ impl XcbConnection {
             atoms,
             auto_float_types,
             randr_base,
-            numlock_mask: None,
+            numlock_mask,
         })
-    }
-
-    /// Set the numlock mask, allowing it to be ignored
-    pub fn set_numlock_mask(&mut self, mask: u16) {
-        self.numlock_mask = Some(mask);
     }
 
     // Return the cached atom if it's one we know, falling back to interning the atom if we need to.

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -103,6 +103,14 @@ const EVENT_MASK: &[(u32, u32)] = &[(
         | xcb::EVENT_MASK_SUBSTRUCTURE_NOTIFY,
 )];
 
+const IGNORED_MODIFIERS: &[u16] = &[
+    0, 
+    xcb::MOD_MASK_2 as u16,
+    xcb::MOD_MASK_LOCK as u16,
+    (xcb::MOD_MASK_2 | xcb::MOD_MASK_LOCK) as u16,
+];
+const IGNORED_MOD_MASK: u16 = (xcb::MOD_MASK_2 | xcb::MOD_MASK_LOCK) as u16;
+
 gen_enum_with_slice!(
     /// Enum with X Atoms.
     #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -587,7 +595,7 @@ impl XConn for XcbConnection {
                 xcb::KEY_PRESS => {
                     let e: &xcb::KeyPressEvent = unsafe { xcb::cast_event(&event) };
                     Some(XEvent::KeyPress {
-                        code: KeyCode::from_key_press(e),
+                        code: KeyCode::from_key_press(e, IGNORED_MOD_MASK),
                     })
                 }
 
@@ -831,16 +839,18 @@ impl XConn for XcbConnection {
 
     fn grab_keys(&self, key_bindings: &KeyBindings) {
         for k in key_bindings.keys() {
-            // xcb docs: https://www.mankier.com/3/xcb_grab_key
-            xcb::grab_key(
-                &self.conn,      // xcb connection to X11
-                false,           // don't pass grabbed events through to the client
-                self.root,       // the window to grab: in this case the root window
-                k.mask,          // modifiers to grab
-                k.code,          // keycode to grab
-                GRAB_MODE_ASYNC, // don't lock pointer input while grabbing
-                GRAB_MODE_ASYNC, // don't lock keyboard input while grabbing
-            );
+            for m in IGNORED_MODIFIERS {
+                // xcb docs: https://www.mankier.com/3/xcb_grab_key
+                xcb::grab_key(
+                    &self.conn,      // xcb connection to X11
+                    false,           // don't pass grabbed events through to the client
+                    self.root,       // the window to grab: in this case the root window
+                    k.mask | m,      // modifiers to grab
+                    k.code,          // keycode to grab
+                    GRAB_MODE_ASYNC, // don't lock pointer input while grabbing
+                    GRAB_MODE_ASYNC, // don't lock keyboard input while grabbing
+                );
+            }
         }
 
         // TODO: this needs to be more configurable by the user


### PR DESCRIPTION
I ended up dumping the entire modifier map from `xmodmap -pm`. I considered using `xcb::xproto::get_modifier_mapping` similar to `dwm`, but it doesn't really work because I can't access a "key name to key code" mapping from `XcbConnection` (I assume this is by design).

Currently it only ignores `Num_Lock`, but wouldn't be hard to add `Caps_Lock`, because `Caps_Lock` is always `MOD_MASK_LOCK`. The only somewhat tricky thing is having to account for having both `Num_Lock` and `Caps_Lock` enabled as well.

Let me know if there's anything you want me to change before it can be merged.
