### PR TITLE
added get_text and fixed extent computation in Text

### DIFF
--- a/src/draw/bar/widgets.rs
+++ b/src/draw/bar/widgets.rs
@@ -48,6 +48,11 @@ impl Text {
         }
     }
 
+    /// Borrows the current contents of the widget.
+    pub fn get_text(&self) -> &String {
+        &self.txt
+    }
+
     /// Set the rendered text and trigger a redraw
     pub fn set_text(&mut self, txt: impl Into<String>) {
         let new_text = txt.into();
@@ -74,7 +79,7 @@ impl Widget for Text {
             ctx.rectangle(0.0, 0.0, w, h);
         }
 
-        let (ew, eh) = self.extent.unwrap();
+        let (ew, eh) = self.current_extent(ctx, h)?;
         ctx.font(&self.font, self.point_size)?;
         ctx.color(&self.fg);
 


### PR DESCRIPTION
This fixes an extent computation bug in the Text widget and adds a getter for the box's current value (to aid in implementing `require_draw` for widgets built on top of `Text` widgets).  Some basic code to demonstrate the need for both:


    /// Clock is exactly what the name suggests; it's a clock for your bar.
    pub struct Clock<'a> {
        time_format: &'a str,
        inner_text: Text,
    }

    impl<'a> Clock<'a> {
        ...

        fn update_time(&mut self) {
            self.inner_text.set_text(self.time_string());
        }

        fn time_string(&self) -> String {
            Local::now().format(self.time_format).to_string()
        }
    }

    impl<'a> Widget for Clock<'a> {
        fn draw(
            &mut self,
            ctx: &mut dyn DrawContext,
            screen: usize,
            screen_has_focus: bool,
            w: f64,
            h: f64,
        ) -> Result<()> {
            self.update_time();
            self.inner_text.draw(ctx, screen, screen_has_focus, w, h)
        }

        fn require_draw(&self) -> bool {
            self.time_string() != self.inner_text.get_text()
        }

        ...
    }

