### PR TITLE
added trait derivations to Position and WindowType

### DIFF
--- a/src/draw/bar/statusbar.rs
+++ b/src/draw/bar/statusbar.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 /// The position of a status bar
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Position {
     /// Top of the screen
     Top,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -153,6 +153,7 @@ mod inner {
     }
 
     /// An EWMH Window type
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum WindowType {
         /// A dock / status bar
         Dock,


### PR DESCRIPTION
Adds some trait derivations to `Position`.  While I was at it I also scanned the codebase for other possibly missing derivations and added the one instance I found.