### PR TITLE
refactored TextStyle to allow const construction

### DIFF
--- a/src/draw/bar/widgets.rs
+++ b/src/draw/bar/widgets.rs
@@ -36,7 +36,7 @@ impl Text {
     ) -> Self {
         Self {
             txt: txt.into(),
-            font: style.font.clone(),
+            font: style.font.to_string(),
             point_size: style.point_size,
             fg: style.fg,
             bg: style.bg,
@@ -162,7 +162,7 @@ impl Workspaces {
     ) -> Self {
         Self {
             workspaces: meta_from_names(workspace_names),
-            font: style.font.clone(),
+            font: style.font.to_string(),
             point_size: style.point_size,
             focused_ws: vec![], // set in startup hook
             require_draw: false,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -58,9 +58,9 @@ mod inner {
 
     #[derive(Clone, Debug, PartialEq)]
     /// A set of styling options for a text string
-    pub struct TextStyle {
+    pub struct TextStyle<'s> {
         /// Pango font name to use for rendering
-        pub font: String,
+        pub font: &'s str,
         /// Point size to render the font at
         pub point_size: i32,
         /// Foreground color in 0xRRGGBB format
@@ -82,6 +82,7 @@ mod inner {
     impl Color {
         /// Create a new Color from a hex encoded u32: 0xRRGGBB or 0xRRGGBBAA
         pub fn new_from_hex(hex: u32) -> Self {
+            // TODO: double check if this produces correct results when alpha is omitted.
             let floats: Vec<f64> = hex
                 .to_be_bytes()
                 .iter()
@@ -90,6 +91,26 @@ mod inner {
 
             let (r, g, b, a) = (floats[0], floats[1], floats[2], floats[3]);
             Self { r, g, b, a }
+        }
+
+        /// Creates a new Color from its R, G and B channels.
+        pub const fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+            Self {
+                r: r as f64 / 255.0,
+                g: g as f64 / 255.0,
+                b: b as f64 / 255.0,
+                a: 1.0,
+            }
+        }
+
+        /// Creates a new Color from its R, G, B and A channels.
+        pub const fn from_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+            Self {
+                r: r as f64 / 255.0,
+                g: g as f64 / 255.0,
+                b: b as f64 / 255.0,
+                a: a as f64 / 255.0,
+            }
         }
 
         /// The RGB information of this color as 0.0-1.0 range floats representing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A tiling window manager in the style of Xmonad
 #![warn(missing_docs)]
 #![deny(clippy::all)]
+#![feature(const_fn_floating_point_arithmetic)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
A few tweaks to allow `TextStyle`s to be created as constants, eg:

    /// The default text style for widgets.
    pub const DEFAULT_TEXT_STYLE: TextStyle = TextStyle {
        font: "ProFont For Powerline",
        point_size: 11,
        fg: Color::from_rgb(0xEB, 0xDB, 0xB2),
        bg: Some(Color::from_rgb(0xEB, 0xDB, 0xB2)),
        padding: (2.0, 2.0),
    };
