### PR TITLE
refactored TextStyle to allow const construction

### DIFF
--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -8,12 +8,20 @@ const PROFONT: &str = "ProFont For Powerline";
 const FIRA: &str = "Fira Code";
 const SERIF: &str = "Serif";
 
-const BLACK: u32 = 0x282828ff;
-const GREY: u32 = 0x3c3836ff;
-const WHITE: u32 = 0xebdbb2ff;
-const PURPLE: u32 = 0xb16286ff;
-const BLUE: u32 = 0x458588ff;
-const RED: u32 = 0xcc241dff;
+const BLACK: Color = Color::new_from_hex(0x2828_28FF);
+const GREY: Color = Color::new_from_hex(0x3C38_36FF);
+const WHITE: Color = Color::new_from_hex(0xEBDB_B2FF);
+const PURPLE: Color = Color::new_from_hex(0xB162_86FF);
+const BLUE: Color = Color::new_from_hex(0x4585_88FF);
+const RED: Color = Color::new_from_hex(0xCC24_1DFF);
+
+const STYLE: TextStyle = TextStyle {
+    font: PROFONT,
+    point_size: 11,
+    fg: WHITE,
+    bg: Some(BLACK),
+    padding: (2.0, 2.0),
+};
 
 fn main() -> Result<()> {
     bar_draw()?;
@@ -23,19 +31,12 @@ fn main() -> Result<()> {
 
 fn bar_draw() -> Result<()> {
     let workspaces = &["1", "2", "3", "4", "5", "6"];
-    let style = TextStyle {
-        font: PROFONT.to_string(),
-        point_size: 11,
-        fg: WHITE.into(),
-        bg: Some(BLACK.into()),
-        padding: (2.0, 2.0),
-    };
     let highlight = BLUE;
     let empty_ws = GREY;
     let mut bar = dwm_bar(
         Box::new(XCBDraw::new()?),
         HEIGHT,
-        &style,
+        &STYLE,
         highlight,
         empty_ws,
         workspaces,

--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -68,20 +68,20 @@ fn simple_draw() -> Result<()> {
 
     let mut ctx = drw.context_for(id)?;
 
-    ctx.color(&WHITE.into());
+    ctx.color(&WHITE);
     ctx.rectangle(0.0, 0.0, w as f64, HEIGHT as f64);
     ctx.translate(1.0, 1.0);
 
-    ctx.color(&BLACK.into());
+    ctx.color(&BLACK);
     ctx.font(PROFONT, 12)?;
     let (offset, _) = ctx.text("this is a simple test", 0.0, (0.0, 8.0))?;
 
-    ctx.color(&RED.into());
+    ctx.color(&RED);
     ctx.font(SERIF, 10)?;
     ctx.translate((offset + 5.0) as f64, 0.0);
     let (offset, _) = ctx.text("BORK BORK!", 0.0, (0.0, 0.0))?;
 
-    ctx.color(&PURPLE.into());
+    ctx.color(&PURPLE);
     ctx.font(FIRA, 10)?;
     ctx.translate((offset + 5.0) as f64, 0.0);
     ctx.text("Look at all the colors!", 0.0, (0.0, 0.0))?;

--- a/src/draw/bar/widgets.rs
+++ b/src/draw/bar/widgets.rs
@@ -36,7 +36,7 @@ impl Text {
     ) -> Self {
         Self {
             txt: txt.into(),
-            font: style.font.clone(),
+            font: style.font.to_string(),
             point_size: style.point_size,
             fg: style.fg,
             bg: style.bg,
@@ -162,7 +162,7 @@ impl Workspaces {
     ) -> Self {
         Self {
             workspaces: meta_from_names(workspace_names),
-            font: style.font.clone(),
+            font: style.font.to_string(),
             point_size: style.point_size,
             focused_ws: vec![], // set in startup hook
             require_draw: false,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -112,7 +112,11 @@ mod inner {
         /// The RGB information of this color as 0.0-1.0 range floats representing
         /// proportions of 255 for each of R, G, B
         pub fn rgb(&self) -> (f64, f64, f64) {
-            (self.r as f64 / 255.0, self.g as f64 / 255.0, self.b as f64 / 255.0)
+            (
+                self.r as f64 / 255.0,
+                self.g as f64 / 255.0,
+                self.b as f64 / 255.0,
+            )
         }
 
         /// The RGBA information of this color as 0.0-1.0 range floats representing

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -112,11 +112,8 @@ mod inner {
         /// The RGB information of this color as 0.0-1.0 range floats representing
         /// proportions of 255 for each of R, G, B
         pub fn rgb(&self) -> (f64, f64, f64) {
-            (
-                self.r as f64 / 255.0,
-                self.g as f64 / 255.0,
-                self.b as f64 / 255.0,
-            )
+            let (r, g, b, _) = self.rgba();
+            (r, g, b)
         }
 
         /// The RGBA information of this color as 0.0-1.0 range floats representing

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -86,14 +86,14 @@ mod inner {
                 Self {
                     r: (hex >> 24) as u8,
                     g: (hex >> 16) as u8,
-                    b: (hex >> 08) as u8,
-                    a: (hex >> 00) as u8,
+                    b: (hex >> 8) as u8,
+                    a: (hex >> 0) as u8,
                 }
             } else {
                 Self {
                     r: (hex >> 16) as u8,
-                    g: (hex >> 08) as u8,
-                    b: (hex >> 00) as u8,
+                    g: (hex >> 8) as u8,
+                    b: (hex >> 0) as u8,
                     a: 0xFF,
                 }
             }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -87,13 +87,13 @@ mod inner {
                     r: (hex >> 24) as u8,
                     g: (hex >> 16) as u8,
                     b: (hex >> 8) as u8,
-                    a: (hex >> 0) as u8,
+                    a: hex as u8,
                 }
             } else {
                 Self {
                     r: (hex >> 16) as u8,
                     g: (hex >> 8) as u8,
-                    b: (hex >> 0) as u8,
+                    b: hex as u8,
                     a: 0xFF,
                 }
             }


### PR DESCRIPTION
A few tweaks to allow `TextStyle`s to be created as constants, eg:

    /// The default text style for widgets.
    pub const DEFAULT_TEXT_STYLE: TextStyle = TextStyle {
        font: "ProFont For Powerline",
        point_size: 11,
        fg: Color::from_rgb(0xEB, 0xDB, 0xB2),
        bg: Some(Color::from_rgb(0xEB, 0xDB, 0xB2)),
        padding: (2.0, 2.0),
    };

Note:  In order to create `Color`s in a `const` context it was necessary to switch the channel representation to integers.  As a nice side effect of doing that I also fixed a bug in `new_from_hex` caused by the ambiguous u32 representation scheme it expects, and that allowed some other simplifications.