### PR TITLE
Allow for moving clients to a target workspace on spawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,10 @@ test-and-publish:
 .PHONY: run-embeded
 run-embeded:
 	cargo build --examples && ./scripts/xephyr.sh
+
+.PHONY: check-all
+check-all:
+	cargo test
+	cargo fmt --all -- --check
+	cargo clippy --workspace --all-targets
+	cargo rustdoc --all-features -- -D warnings

--- a/src/contrib/layouts.rs
+++ b/src/contrib/layouts.rs
@@ -6,7 +6,7 @@ use crate::{
 
 /**
  * A layout that aims to mimic the feel of having multiple pieces of paper fanned out on a desk,
- * inspired by http://10gui.com/
+ * inspired by <http://10gui.com/>
  *
  * Without access to the custom hardware required for 10gui, we instead have to rely on the WM
  * actions we have available: n_main is ignored and instead, the focused client takes up ratio% of

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -346,16 +346,19 @@ impl<'a> WindowManager<'a> {
         }
 
         self.client_map.insert(id, client);
-        self.conn.mark_new_window(id);
-        self.conn.focus_client(id);
-        self.client_gained_focus(id);
-
         self.conn.set_client_workspace(id, wix);
-        self.apply_layout(wix);
-        self.map_window_if_needed(id);
 
-        let s = self.screens.focused().unwrap();
-        self.conn.warp_cursor(Some(id), s);
+        if wix == self.active_ws_index() {
+            self.conn.mark_new_window(id);
+            self.conn.focus_client(id);
+            self.client_gained_focus(id);
+
+            self.apply_layout(wix);
+            self.map_window_if_needed(id);
+
+            let s = self.screens.focused().unwrap();
+            self.conn.warp_cursor(Some(id), s);
+        }
     }
 
     fn add_client_to_workspace(&mut self, wix: usize, id: WinId) {

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -337,9 +337,9 @@ impl<'a> WindowManager<'a> {
         };
 
         let floating = self.conn.window_should_float(id, self.floating_classes);
-        let wix = self.active_ws_index();
-        let mut client = Client::new(id, wm_name, wm_class, wix, floating);
+        let mut client = Client::new(id, wm_name, wm_class, self.active_ws_index(), floating);
         run_hooks!(new_client, self, &mut client);
+        let wix = client.workspace();
 
         if client.wm_managed && !floating {
             self.add_client_to_workspace(wix, id);

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -169,19 +169,19 @@ const UNMANAGED_WINDOW_TYPES: &[Atom] = &[Atom::NetWindowTypeDock, Atom::NetWind
  * accordingly if you need access to something that isn't currently passed through
  * to the WindowManager event loop.
  *
- * https://tronche.com/gui/x/xlib/events/types.html
- * https://github.com/rtbo/rust-xcb/xml/xproto.xml
+ * <https://tronche.com/gui/x/xlib/events/types.html>
+ * <https://github.com/rtbo/rust-xcb/xml/xproto.xml>
  */
 #[derive(Debug, Clone)]
 pub enum XEvent {
-    /// xcb docs: https://www.mankier.com/3/xcb_button_press_event_t
-    /// xcb docs: https://www.mankier.com/3/xcb_motion_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_button_press_event_t>
+    /// xcb docs: <https://www.mankier.com/3/xcb_motion_notify_event_t>
     MouseEvent(MouseEvent),
 
-    /// xcb docs: https://www.mankier.com/3/xcb_input_device_key_press_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_input_device_key_press_event_t>
     KeyPress(KeyCode),
 
-    /// xcb docs: https://www.mankier.com/3/xcb_map_request_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_map_request_event_t>
     MapRequest {
         /// The ID of the window that wants to be mapped
         id: WinId,
@@ -189,7 +189,7 @@ pub enum XEvent {
         ignore: bool,
     },
 
-    /// xcb docs: https://www.mankier.com/3/xcb_enter_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_enter_notify_event_t>
     Enter {
         /// The ID of the window that was entered
         id: WinId,
@@ -199,7 +199,7 @@ pub enum XEvent {
         wpt: Point,
     },
 
-    /// xcb docs: https://www.mankier.com/3/xcb_enter_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_enter_notify_event_t>
     Leave {
         /// The ID of the window that was left
         id: WinId,
@@ -209,19 +209,19 @@ pub enum XEvent {
         wpt: Point,
     },
 
-    /// xcb docs: https://www.mankier.com/3/xcb_destroy_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_destroy_notify_event_t>
     Destroy {
         /// The ID of the window being destroyed
         id: WinId,
     },
 
-    /// xcb docs: https://www.mankier.com/3/xcb_randr_screen_change_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_randr_screen_change_notify_event_t>
     ScreenChange,
 
-    /// xcb docs: https://www.mankier.com/3/xcb_randr_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_randr_notify_event_t>
     RandrNotify,
 
-    /// xcb docs: https://www.mankier.com/3/xcb_configure_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_configure_notify_event_t>
     ConfigureNotify {
         /// The ID of the window that had a property changed
         id: WinId,
@@ -231,7 +231,7 @@ pub enum XEvent {
         is_root: bool,
     },
 
-    /// xcb docs: https://www.mankier.com/3/xcb_property_notify_event_t
+    /// xcb docs: <https://www.mankier.com/3/xcb_property_notify_event_t>
     PropertyNotify {
         /// The ID of the window that had a property changed
         id: WinId,
@@ -241,7 +241,7 @@ pub enum XEvent {
         is_root: bool,
     },
 
-    /// https://www.mankier.com/3/xcb_client_message_event_t
+    /// <https://www.mankier.com/3/xcb_client_message_event_t>
     ClientMessage {
         /// The ID of the window that sent the message
         id: WinId,

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -137,7 +137,7 @@ mod inner {
         type Error = anyhow::Error;
 
         fn try_from(s: &str) -> Result<Color> {
-            let hex = u32::from_str_radix(s.strip_prefix('#').unwrap_or_else(|| &s), 16)?;
+            let hex = u32::from_str_radix(s.strip_prefix('#').unwrap_or(&s), 16)?;
 
             if s.len() == 7 {
                 Ok(Self::new_from_hex((hex << 8) + 0xFF))


### PR DESCRIPTION
Fix for #80 

This has the desired behaviour when running locally for me:
```rust
#[macro_use]
extern crate penrose;

use penrose::{
    bindings::MouseEvent,
    contrib::{
        extensions::Scratchpad,
        hooks::{ClientSpawnRules, SpawnRule},
        layouts::paper,
    },
    draw::{dwm_bar, TextStyle, XCBDraw},
    helpers::index_selectors,
    layout::{bottom_stack, monocle, side_stack, Layout, LayoutConf},
    Backward, Config, Forward, Less, More, Result, Selector, WindowManager, XcbConnection,
};

use simplelog::{LevelFilter, SimpleLogger};

const HEIGHT: usize = 18;
const N_MAIN: u32 = 1;
const RATIO: f32 = 0.6;
const PROFONT: &str = "ProFont For Powerline";

const BLACK: u32 = 0x282828ff;
const GREY: u32 = 0x3c3836ff;
const WHITE: u32 = 0xebdbb2ff;
const BLUE: u32 = 0x458588ff;

fn my_layouts() -> Vec<Layout> {
    let mut mono_conf = LayoutConf::default();
    mono_conf.follow_focus = true;
    mono_conf.gapless = true;

    let mut paper_conf = mono_conf;
    paper_conf.allow_wrapping = false;

    vec![
        Layout::new("[side]", LayoutConf::default(), side_stack, N_MAIN, RATIO),
        Layout::new("[botm]", LayoutConf::default(), bottom_stack, N_MAIN, RATIO),
        Layout::new("[papr]", paper_conf, paper, N_MAIN, RATIO),
        Layout::new("[mono]", mono_conf, monocle, N_MAIN, RATIO),
    ]
}

fn main() -> Result<()> {
    SimpleLogger::init(LevelFilter::Debug, simplelog::Config::default())?;
    let mut config = Config::default();
    config.floating_classes = &["rofi", "dmenu", "dunst", "polybar", "pinentry-gtk-2"];
    config.layouts = my_layouts();

    let sp = Scratchpad::new("st", 0.8, 0.8);
    sp.register(&mut config);

    config
        .hooks
        .push(ClientSpawnRules::new(vec![SpawnRule::ClassName(
            "thunar", 3,
        )]));

    config.hooks.push(Box::new(dwm_bar(
        Box::new(XCBDraw::new()?),
        HEIGHT,
        &TextStyle {
            font: PROFONT.to_string(),
            point_size: 11,
            fg: WHITE.into(),
            bg: Some(BLACK.into()),
            padding: (2.0, 2.0),
        },
        BLUE,
        GREY,
        &config.workspaces,
    )?));

    let key_bindings = gen_keybindings! {
        "A-C-semicolon" => run_external!("rofi-apps");
        "A-C-Return" => run_external!("st");
        "A-C-slash" => sp.toggle();

        // client management
        "A-C-j" => run_internal!(cycle_client, Forward);
        "A-C-k" => run_internal!(cycle_client, Backward);
        "A-C-S-j" => run_internal!(drag_client, Forward);
        "A-C-S-k" => run_internal!(drag_client, Backward);
        "A-C-f" => run_internal!(toggle_client_fullscreen, &Selector::Focused);
        "A-C-q" => run_internal!(kill_client);

        // workspace management
        "A-C-Tab" => run_internal!(toggle_workspace);
        "A-C-period" => run_internal!(cycle_workspace, Forward);
        "A-C-comma" => run_internal!(cycle_workspace, Backward);
        "A-C-S-bracketright" => run_internal!(drag_workspace, Forward);
        "A-C-S-bracketleft" => run_internal!(drag_workspace, Backward);

        // Layout management
        "A-C-grave" => run_internal!(cycle_layout, Forward);
        "A-C-S-grave" => run_internal!(cycle_layout, Backward);
        "A-C-Up" => run_internal!(update_max_main, More);
        "A-C-Down" => run_internal!(update_max_main, Less);
        "A-C-Right" => run_internal!(update_main_ratio, More);
        "A-C-Left" => run_internal!(update_main_ratio, Less);

        "A-C-Escape" => run_internal!(exit);

        refmap [ config.ws_range() ] in {
            "A-C-{}" => focus_workspace [ index_selectors(config.workspaces.len()) ];
            "A-C-S-{}" => client_to_workspace [ index_selectors(config.workspaces.len()) ];
        };
    };

    let mouse_bindings = gen_mousebindings! {
        Press Right + [Alt, Ctrl] => |wm: &mut WindowManager, _: &MouseEvent| wm.cycle_workspace(Forward),
        Press Left + [Alt, Ctrl] => |wm: &mut WindowManager, _: &MouseEvent| wm.cycle_workspace(Backward)
    };

    let conn = XcbConnection::new()?;
    let mut wm = WindowManager::init(config, &conn);
    wm.grab_keys_and_run(key_bindings, mouse_bindings);

    Ok(())
}
```