### PR TITLE
Assign floating clients to specific workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose"
-version = "0.1.12"
+version = "0.2.0"
 edition = "2018"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,21 @@ check-all:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets
 	cargo rustdoc --all-features -- -D warnings
+
+
+# GitHub helpers using the official gh GitHub CLI
+.PHONY: pr
+pr:
+	gh pr create
+
+.PHONY: list-prs
+list-prs:
+	gh pr list
+
+.PHONY: list-issues
+list-issues:
+	gh issue list
+
+.PHONY: new-issue
+new-issue:
+	gh issue create

--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -14,7 +14,7 @@ pub struct Client {
     wm_class: String,
     workspace: usize,
     // state flags
-    floating: bool,
+    pub(crate) floating: bool,
     pub(crate) fullscreen: bool,
     pub(crate) mapped: bool,
     pub(crate) wm_managed: bool,
@@ -22,7 +22,7 @@ pub struct Client {
 
 impl Client {
     /// Track a new client window on a specific workspace
-    pub fn new(
+    pub(crate) fn new(
         id: WinId,
         wm_name: String,
         wm_class: String,

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -276,6 +276,9 @@ pub trait XConn {
     /// Reposition the window identified by 'id' to the specifed region
     fn position_window(&self, id: WinId, r: Region, border: u32, stack_above: bool);
 
+    /// Raise the window to the top of the stack so it renders above peers
+    fn raise_window(&self, id: WinId);
+
     /// Mark the given window as newly created
     fn mark_new_window(&self, id: WinId);
 
@@ -648,6 +651,11 @@ impl XConn for XcbConnection {
 
         // xcb docs: https://www.mankier.com/3/xcb_configure_window
         xcb::configure_window(&self.conn, id, &args);
+    }
+
+    fn raise_window(&self, id: WinId) {
+        // xcb docs: https://www.mankier.com/3/xcb_configure_window
+        xcb::configure_window(&self.conn, id, &[(STACK_MODE, STACK_ABOVE)]);
     }
 
     fn mark_new_window(&self, id: WinId) {
@@ -1042,6 +1050,7 @@ impl XConn for MockXConn {
         Point::new(0, 0)
     }
     fn position_window(&self, _: WinId, _: Region, _: u32, _: bool) {}
+    fn raise_window(&self, _: WinId) {}
     fn mark_new_window(&self, _: WinId) {}
     fn map_window(&self, _: WinId) {}
     fn unmap_window(&self, _: WinId) {}


### PR DESCRIPTION
issue #82 

- adding github helper targets to Makefile
- updating dangerfile
- assigning floating clients to specific workspaces
- bumping to 0.2.0 due to change in public APIs for XConnection and Client


To begin with, this simply ensures that floating clients are assigned to the
workspace they are spawned on and that they do not overlap the status bar. This
does not yet implement toggling floating state or moving floating clients.
