### PR TITLE
#85 Unmanaged window types should never be held in WindowManager state

### DIFF
--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -143,7 +143,7 @@ pub fn index_selectors<'a, T>(len: usize) -> Vec<Selector<'a, T>> {
 
 // Helper functions for XCB based operations
 pub(crate) mod xcb_util {
-    use crate::{data_types::Region, Result};
+    use crate::{data_types::Region, xconnection::Atom, Result};
     use anyhow::anyhow;
 
     pub fn intern_atom(conn: &xcb::Connection, name: &str) -> Result<u32> {
@@ -196,13 +196,13 @@ pub(crate) mod xcb_util {
         );
 
         xcb::change_property(
-            &conn,                                      // xcb connection to X11
-            xcb::PROP_MODE_REPLACE as u8,               // discard current prop and replace
-            id,                                         // window to change prop on
-            intern_atom(&conn, "_NET_WM_WINDOW_TYPE")?, // prop to change
-            intern_atom(&conn, "UTF8_STRING")?,         // type of prop
-            8,                                          // data format (8/16/32-bit)
-            window_type.as_bytes(),                     // data
+            &conn,                                               // xcb connection to X11
+            xcb::PROP_MODE_REPLACE as u8,                        // discard current prop and replace
+            id,                                                  // window to change prop on
+            intern_atom(&conn, Atom::NetWmWindowType.as_ref())?, // prop to change
+            intern_atom(&conn, Atom::UTF8String.as_ref())?,      // type of prop
+            8,                                                   // data format (8/16/32-bit)
+            window_type.as_bytes(),                              // data
         );
 
         xcb::map_window(&conn, id);

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -1092,7 +1092,7 @@ mod tests {
 
     #[test]
     fn worspace_switching_with_active_clients() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
 
         // add clients to the first workspace: final client should have focus
@@ -1114,7 +1114,7 @@ mod tests {
 
     #[test]
     fn killing_a_client_removes_it_from_the_workspace() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0);
         wm.kill_client();
@@ -1124,7 +1124,7 @@ mod tests {
 
     #[test]
     fn kill_client_kills_focused_not_first() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 5, 0); // 50 40 30 20 10, 50 focused
         assert_eq!(wm.active_ws_index(), 0);
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn moving_then_deleting_clients() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 2, 0);
         wm.client_to_workspace(&Selector::Index(1));
@@ -1153,7 +1153,7 @@ mod tests {
 
     #[test]
     fn client_to_workspace_inserts_at_head() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 2, 0); // [20, 10]
         wm.client_to_workspace(&Selector::Index(1)); // 20 -> ws::1
@@ -1168,7 +1168,7 @@ mod tests {
 
     #[test]
     fn client_to_workspace_sets_focus() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 2, 0); // [20, 10]
         wm.client_to_workspace(&Selector::Index(1)); // 20 -> ws::1
@@ -1180,7 +1180,7 @@ mod tests {
 
     #[test]
     fn client_to_invalid_workspace_is_noop() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
@@ -1191,7 +1191,7 @@ mod tests {
 
     #[test]
     fn client_to_screen_sets_correct_workspace() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn client_to_invalid_screen_is_noop() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
@@ -1212,7 +1212,7 @@ mod tests {
 
     #[test]
     fn x_focus_events_set_workspace_focus() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 5, 0); // focus on last client: 50
         wm.client_gained_focus(10);
@@ -1222,7 +1222,7 @@ mod tests {
 
     #[test]
     fn focus_workspace_sets_focus_in_ring() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         assert_eq!(wm.workspaces.focused_index(), 0);
         assert_eq!(wm.workspaces.focused_index(), wm.active_ws_index());
@@ -1233,7 +1233,7 @@ mod tests {
 
     #[test]
     fn dragging_clients_forward_from_index_0() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 5, 0); // focus on last client (50) ix == 0
 
@@ -1260,7 +1260,7 @@ mod tests {
 
     #[test]
     fn getting_all_clients_on_workspace() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
 
         add_n_clients(&mut wm, 3, 0);
@@ -1276,7 +1276,7 @@ mod tests {
 
     #[test]
     fn getting_all_workspaces_of_window() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
 
         add_n_clients(&mut wm, 3, 0);
@@ -1289,7 +1289,7 @@ mod tests {
 
     #[test]
     fn selector_screen() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0);
 
@@ -1304,7 +1304,7 @@ mod tests {
 
     #[test]
     fn selector_workspace() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 1, 0);
 
@@ -1319,7 +1319,7 @@ mod tests {
 
     #[test]
     fn selector_client() {
-        let conn = MockXConn::new(test_screens(), vec![]);
+        let conn = MockXConn::new(test_screens(), vec![], vec![]);
         let mut wm = wm_with_mock_conn(test_layouts(), &conn);
         add_n_clients(&mut wm, 4, 0);
 

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -1348,4 +1348,20 @@ mod tests {
             wm.client_map.get(&10)
         );
     }
+
+    #[test]
+    fn unmanaged_window_types_are_not_tracked() {
+        // Setting the unmanaged window IDs here sets the return of
+        // MockXConn.is_managed_window to false for those IDs
+        let conn = MockXConn::new(test_screens(), vec![], vec![10]);
+        let mut wm = wm_with_mock_conn(test_layouts(), &conn);
+
+        wm.handle_map_request(10, false); // should not be tiled
+        assert!(wm.client_map.get(&10).is_none());
+        assert!(wm.workspaces[0].is_empty());
+
+        wm.handle_map_request(20, false); // should be tiled
+        assert!(wm.client_map.get(&20).is_some());
+        assert!(wm.workspaces[0].len() == 1);
+    }
 }

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -1021,15 +1021,17 @@ pub struct MockXConn {
     screens: Vec<Screen>,
     events: Cell<Vec<XEvent>>,
     focused: Cell<WinId>,
+    unmanaged_ids: Vec<WinId>,
 }
 
 impl MockXConn {
     /// Set up a new MockXConn with pre-defined Screens and an event stream to pull from
-    pub fn new(screens: Vec<Screen>, events: Vec<XEvent>) -> Self {
+    pub fn new(screens: Vec<Screen>, events: Vec<XEvent>, unmanaged_ids: Vec<WinId>) -> Self {
         MockXConn {
             screens,
             events: Cell::new(events),
             focused: Cell::new(0),
+            unmanaged_ids,
         }
     }
 }
@@ -1078,8 +1080,8 @@ impl XConn for MockXConn {
     fn window_should_float(&self, _: WinId, _: &[&str]) -> bool {
         false
     }
-    fn is_managed_window(&self, _: WinId) -> bool {
-        true
+    fn is_managed_window(&self, id: WinId) -> bool {
+        !self.unmanaged_ids.contains(&id)
     }
     fn warp_cursor(&self, _: Option<WinId>, _: &Screen) {}
     fn window_geometry(&self, _: WinId) -> Result<Region> {

--- a/tests/hook_tests.rs
+++ b/tests/hook_tests.rs
@@ -1,3 +1,4 @@
+// Check that each Hook variant is called at the expected points
 use penrose::{
     client::Client,
     data_types::WinId,
@@ -99,7 +100,8 @@ macro_rules! hook_test(
 
             let conn = MockXConn::new(
                 vec![common::simple_screen(0), common::simple_screen(1)],
-                events
+                events,
+                vec![],
             );
             let mut wm = WindowManager::init(config, &conn);
             wm.grab_keys_and_run(common::test_bindings(), HashMap::new());


### PR DESCRIPTION
It looks like this was previously handled by accident by completely ignoring windows that had a `_NET_WM_WINDOW_TYPE` that was marked as always floating (e.g. docks, toolbars, notifications etc). The work done to map floating windows per workspace then started picking up these window types as floating and started to tile them. This seems to imply that status bar programs (polybar, lemonbar, and the built in status bar) are not setting `override_redirect` when they send their map request?

This PR ensures that (based on type) we never manage `_NET_WM_WINDOW_TYPE_DOCK` or `_NET_WM_WINDOW_TYPE_TOOLBAR` but I also need to set the built in toolbar to override redirect as well which will be done in its own PR.