### PR TITLE
StubXConn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A tiling window manager in the style of Xmonad
 #![warn(missing_docs)]
 #![deny(clippy::all)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Adding a new `StubXConn` trait that has a dfault implementation for `XConn` to simplify writing test cases that rely on X server interaction. The existing `MockXConn` is now written using this and it prevents having to:

1. Write a full `XConn` impl if you only need to interact with a handful of methods
2. Provide harmful stub default implementations of the `XConn` methods that should never be used by a "real" impl

