### PR TITLE
Issue 91

### DIFF
--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -614,7 +614,7 @@ pub struct XcbConnection {
     check_win: WinId,
     atoms: HashMap<Atom, u32>,
     auto_float_types: Vec<u32>,
-    dont_manage_types: Vec<String>,
+    dont_manage_types: Vec<u32>,
     randr_base: u8,
 }
 
@@ -647,9 +647,9 @@ impl XcbConnection {
             .map(|atom| *atoms.get(&atom).unwrap())
             .collect();
 
-        let dont_manage_types: Vec<String> = UNMANAGED_WINDOW_TYPES
+        let dont_manage_types: Vec<u32> = UNMANAGED_WINDOW_TYPES
             .iter()
-            .map(|&atom| atom.as_ref().to_string())
+            .map(|atom| *atoms.get(&atom).unwrap())
             .collect();
 
         let check_win = conn.generate_id();
@@ -1136,12 +1136,7 @@ impl XConn for XcbConnection {
     }
 
     fn is_managed_window(&self, id: WinId) -> bool {
-        if let Ok(s) = self.str_prop(id, Atom::NetWmWindowType.as_ref()) {
-            let ty = s.split('\0').collect::<Vec<&str>>()[0].to_string();
-            !self.dont_manage_types.contains(&ty)
-        } else {
-            true // manage window by default
-        }
+        !self.window_has_type_in(id, &self.dont_manage_types)
     }
 
     fn window_geometry(&self, id: WinId) -> Result<Region> {

--- a/src/draw/bar/statusbar.rs
+++ b/src/draw/bar/statusbar.rs
@@ -4,6 +4,7 @@ use crate::{
     data_types::{Region, WinId},
     draw::{Color, Draw, DrawContext, Widget, WindowType},
     hooks::Hook,
+    xconnection::Atom,
     Result, WindowManager,
 };
 
@@ -55,6 +56,10 @@ impl<Ctx: DrawContext> StatusBar<Ctx> {
     }
 
     fn init_for_screens(&mut self) -> Result<()> {
+        let name = Atom::NetWmName.as_ref();
+        let class = Atom::WmClass.as_ref();
+        let s = "penrose-statusbar";
+
         self.screens = self
             .drw
             .screen_sizes()?
@@ -65,21 +70,20 @@ impl<Ctx: DrawContext> StatusBar<Ctx> {
                     Position::Top => sy as usize,
                     Position::Bottom => sh as usize - self.hpx,
                 };
-                let id = self
-                    .drw
-                    .new_window(
-                        &WindowType::Dock,
-                        true, // override_redirect
-                        sx as usize,
-                        y,
-                        sw as usize,
-                        self.hpx,
-                    )
-                    .unwrap();
+                let id = self.drw.new_window(
+                    &WindowType::Dock,
+                    true, // override_redirect
+                    sx as usize,
+                    y,
+                    sw as usize,
+                    self.hpx,
+                )?;
+                self.drw.set_str_prop(id, name, s)?;
+                self.drw.set_str_prop(id, class, s)?;
 
-                (id, sw as f64)
+                Ok((id, sw as f64))
             })
-            .collect();
+            .collect::<Result<Vec<(u32, f64)>>>()?;
 
         Ok(())
     }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -211,6 +211,10 @@ mod inner {
         fn unmap_window(&self, id: WinId);
         /// Destroy the target window
         fn destroy_window(&self, id: WinId);
+        /// Set a string property on the target window
+        fn set_str_prop(&self, id: WinId, prop: &str, value: &str) -> Result<()>;
+        /// Set an atom property on the target window
+        fn set_atom_prop(&self, id: WinId, prop: &str, value: u32) -> Result<()>;
     }
 
     /// Used for simple drawing to the screen
@@ -333,6 +337,14 @@ mod inner {
 
         fn destroy_window(&self, id: WinId) {
             xcb::destroy_window(&self.conn, id);
+        }
+
+        fn set_str_prop(&self, id: WinId, prop: &str, value: &str) -> Result<()> {
+            xcb_util::set_str_prop(&self.conn, id, prop, value)
+        }
+
+        fn set_atom_prop(&self, id: WinId, prop: &str, value: u32) -> Result<()> {
+            xcb_util::set_atom_prop(&self.conn, id, prop, value)
         }
     }
 


### PR DESCRIPTION
Sets `_NET_WM_WINDOW_TYPE` as an atom, not a string and reads this correctly in `XcbConnection` to handle unmanaged clients correctly.