### PR TITLE
initial work on getting serde support in place for #98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ cairo-rs = { version = "0.9.1", features = ["xcb"], optional = true }
 cairo-sys-rs = { version = "0.10.0", optional = true }
 pangocairo = { version = "0.10.0", optional = true }
 pango = { version = "0.9.1", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 xcb = { version = "0.9.0", features = ["randr"], optional = true }
 
 [dev-dependencies]
+serde_json = "1.0"
 simplelog = "0.8.0"
 test-case = "1.0.0"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ check-all:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets --all-features --examples --tests
 	cargo rustdoc --all-features -- -D warnings
-	cargo test
+	cargo test --all-features
 
 .PHONY: doc
 doc:
@@ -25,9 +25,13 @@ examples:
 run-embeded:
 	cargo build --examples && ./scripts/xephyr.sh
 
+.PHONY: test
+test:
+	cargo test --all-features
+
 .PHONY: test-and-publish
 test-and-publish:
-	cargo test && cargo publish
+	cargo test --all-features && cargo publish
 
 
 # GitHub helpers using the official gh GitHub CLI

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -184,7 +184,8 @@ fn main() -> Result<()> {
     // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions
     // such as configuring initial WindowManager state, running custom code / hooks or spawning
     // external processes such as a start-up script.
-    let mut wm = WindowManager::init(config, Box::new(conn), hooks);
+    let mut wm = WindowManager::new(config, Box::new(conn), hooks);
+    wm.init();
 
     // NOTE: If you are using the default XCB backend provided in the penrose xcb module, then the
     //       construction of the XcbConnection and resulting WindowManager can be done using the

--- a/src/contrib/extensions/scratchpad.rs
+++ b/src/contrib/extensions/scratchpad.rs
@@ -45,8 +45,11 @@ impl Scratchpad {
     /// Create a new Scratchpad for holding 'prog'. 'w' and 'h' are the percentage width and height
     /// of the active screen that you want the client to take up when visible.
     /// NOTE: this function will panic if 'w' or 'h' are not within the range 0.0 - 1.0
-    pub fn new(prog: impl Into<String>, w: f32, h: f32) -> Scratchpad {
-        if w < 0.0 || w > 1.0 || h < 0.0 || h > 1.0 {
+    pub fn new<S>(prog: S, w: f32, h: f32) -> Scratchpad
+    where
+        S: Into<String>,
+    {
+        if !(0.0..=1.0).contains(&w) || !(0.0..=1.0).contains(&h) {
             panic!("Scratchpad: w & h must be between 0.0 and 1.0");
         }
 

--- a/src/core/bindings.rs
+++ b/src/core/bindings.rs
@@ -27,6 +27,7 @@ pub(crate) type CodeMap = HashMap<String, u8>;
 
 /// A key press and held modifiers
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct KeyCode {
     /// The held modifier mask
     pub mask: u16,
@@ -52,6 +53,7 @@ impl KeyCode {
 
 /// Known mouse buttons for binding actions
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseButton {
     /// 1
     Left,
@@ -94,6 +96,7 @@ impl TryFrom<u8> for MouseButton {
 
 /// Known modifier keys for bindings
 #[derive(Debug, EnumIter, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ModifierKey {
     /// Control
     Ctrl,
@@ -138,6 +141,7 @@ impl TryFrom<&str> for ModifierKey {
 
 /// A mouse state specification indicating the button and modifiers held
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MouseState {
     button: MouseButton,
     modifiers: Vec<ModifierKey>,
@@ -170,6 +174,7 @@ impl MouseState {
 
 /// The types of mouse events represented by a MouseEvent
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseEventKind {
     /// A button was pressed
     Press,
@@ -181,6 +186,7 @@ pub enum MouseEventKind {
 
 /// A mouse movement or button event
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MouseEvent {
     /// The ID of the window that was contained the click
     pub id: WinId,

--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -7,6 +7,7 @@ use crate::core::data_types::WinId;
  * Primarily state flags and information used when determining which clients
  * to show for a given monitor and how they are tiled.
  */
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Client {
     id: WinId,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -4,6 +4,8 @@ use crate::core::layout::{side_stack, Layout, LayoutConf};
 use std::fmt;
 
 /// The main user facing configuration details
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, PartialEq)]
 pub struct Config {
     /// Default workspace names to use when initialising the WindowManager. Must have at least one element.
     pub workspaces: Vec<String>,

--- a/src/core/data_types.rs
+++ b/src/core/data_types.rs
@@ -24,6 +24,7 @@ pub enum PropVal<'a> {
 
 /// A window type to be specified when creating a new window in the X server
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum WinType {
     /// A simple hidden stub window for facilitating other API calls
     CheckWin,
@@ -36,6 +37,7 @@ pub enum WinType {
 
 /// Config options for X windows (not all are currently implemented)
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum WinConfig {
     /// The border width in pixels
     BorderPx(u32),
@@ -66,6 +68,7 @@ impl From<&WinConfig> for Vec<(u16, u32)> {
 }
 
 /// Window attributes for an X11 client window (not all are curently implemented)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug)]
 pub enum WinAttr {
     /// Border color as an argb hex value
@@ -97,6 +100,7 @@ impl From<&WinAttr> for Vec<(u32, u32)> {
 }
 
 /// An x,y coordinate pair
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub struct Point {
     /// An absolute x coordinate relative to the root window
@@ -115,6 +119,7 @@ impl Point {
 /* Argument enums */
 
 /// Increment / decrement a value
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub enum Change {
     /// increase the value
@@ -124,6 +129,7 @@ pub enum Change {
 }
 
 /// X window border kind
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum Border {
     /// window is urgent
@@ -135,6 +141,7 @@ pub enum Border {
 }
 
 /// An X window / screen position: top left corner + extent
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Region {
     x: u32,

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -102,8 +102,8 @@ impl fmt::Debug for Layout {
     }
 }
 
-// A no-op floating layout that simply satisfies the type required for Layout
-fn floating(_: &[&Client], _: Option<WinId>, _: &Region, _: u32, _: f32) -> Vec<ResizeAction> {
+/// A no-op floating layout that simply satisfies the type required for Layout
+pub fn floating(_: &[&Client], _: Option<WinId>, _: &Region, _: u32, _: f32) -> Vec<ResizeAction> {
     vec![]
 }
 

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -147,8 +147,7 @@ impl WindowManager {
         self.hooks.set(hooks);
         self.workspaces
             .iter_mut()
-            .map(|w| w.restore_layout_functions(&layout_funcs))
-            .collect::<Result<()>>()?;
+            .try_for_each(|w| w.restore_layout_functions(&layout_funcs))?;
 
         util::validate_hydrated_wm_state(self)?;
         self.init();
@@ -1106,8 +1105,10 @@ mod tests {
 
     fn wm_with_mock_conn(events: Vec<XEvent>, unmanaged_ids: Vec<WinId>) -> WindowManager {
         let conn = MockXConn::new(test_screens(), events, unmanaged_ids);
-        let mut conf = Config::default();
-        conf.layouts = test_layouts();
+        let conf = Config {
+            layouts: test_layouts(),
+            ..Default::default()
+        };
         let mut wm = WindowManager::new(conf, Box::new(conn), vec![]);
         wm.init();
 

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -2,6 +2,7 @@
 use crate::core::data_types::{Point, Region};
 
 /// Display information for a connected screen
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Screen {
     /// The current workspace index being displayed

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -73,7 +73,7 @@ impl Workspace {
                 let s = &layout.symbol;
                 match layout_funcs.get(s.as_str()) {
                     Some(f) => {
-                        layout.set_layout_function(f.clone());
+                        layout.set_layout_function(*f);
                         Ok(())
                     }
                     None => Err(PenroseError::HydrationState(format!(

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -67,23 +67,20 @@ impl Workspace {
         &mut self,
         layout_funcs: &HashMap<&str, LayoutFunc>,
     ) -> Result<()> {
-        self.layouts
-            .iter_mut()
-            .map(|layout| {
-                let s = &layout.symbol;
-                match layout_funcs.get(s.as_str()) {
-                    Some(f) => {
-                        layout.set_layout_function(*f);
-                        Ok(())
-                    }
-                    None => Err(PenroseError::HydrationState(format!(
-                        "'{}' is not a known layout symbol: {:?}",
-                        layout.symbol,
-                        layout_funcs.keys()
-                    ))),
+        self.layouts.iter_mut().try_for_each(|layout| {
+            let s = &layout.symbol;
+            match layout_funcs.get(s.as_str()) {
+                Some(f) => {
+                    layout.set_layout_function(*f);
+                    Ok(())
                 }
-            })
-            .collect::<Result<()>>()
+                None => Err(PenroseError::HydrationState(format!(
+                    "'{}' is not a known layout symbol: {:?}",
+                    layout.symbol,
+                    layout_funcs.keys()
+                ))),
+            }
+        })
     }
 
     /// The number of clients currently on this workspace

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -26,6 +26,7 @@ use strum::*;
  * of type safety around their use. Implementors of [XConn] should accept any variant of [Atom]
  * that they are passed by client code.
  */
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(AsRefStr, EnumString, EnumIter, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Atom {
     /// ATOM
@@ -205,6 +206,7 @@ pub(crate) const EWMH_SUPPORTED_ATOMS: &[Atom] = &[
  * <https://tronche.com/gui/x/xlib/events/types.html>
  * <https://github.com/rtbo/rust-xcb/xml/xproto.xml>
  */
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub enum XEvent {
     /// xcb docs: <https://www.mankier.com/3/xcb_button_press_event_t>

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -44,6 +44,7 @@ pub enum DrawError {
 /// Result type for fallible methods on [Draw] and [DrawContext]
 pub type Result<T> = std::result::Result<T, DrawError>;
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 /// A set of styling options for a text string
 pub struct TextStyle {
@@ -59,6 +60,7 @@ pub struct TextStyle {
     pub padding: (f64, f64),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// A simple RGBA based color
 pub struct Color {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@ pub enum PenroseError {
     #[error("unable to rehydrate from serialized state: {0}")]
     HydrationState(String),
 
+    /// Something was inconsistant when attempting to re-create a serialised [WindowManager]
+    #[error("the following serialized client IDs were not known to the X server: {0:?}")]
+    MissingClientIds(Vec<WinId>),
+
     /// An [IO Error][std::io::Error] was encountered
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 #[macro_use]
 pub mod core;
 
@@ -47,6 +51,10 @@ pub enum PenroseError {
     /// See [DrawError][crate::draw::DrawError] for variants.
     #[error(transparent)]
     Draw(#[from] crate::draw::DrawError),
+
+    /// Something was inconsistant when attempting to re-create a serialised [WindowManager]
+    #[error("unable to rehydrate from serialized state: {0}")]
+    HydrationState(String),
 
     /// An [IO Error][std::io::Error] was encountered
     #[error(transparent)]

--- a/src/xcb/draw.rs
+++ b/src/xcb/draw.rs
@@ -28,8 +28,8 @@ mod inner {
         Ok(create_layout(ctx).ok_or_else(|| XcbError::Pango("unable to create layout".into()))?)
     }
 
-    #[derive(Clone, Debug)]
     /// An XCB based [Draw] implementation backed by pango and cairo
+    #[derive(Clone, Debug)]
     pub struct XcbDraw {
         api: crate::xcb::Api,
         fonts: HashMap<String, pango::FontDescription>,
@@ -128,8 +128,8 @@ mod inner {
         }
     }
 
-    #[derive(Clone, Debug)]
     /// An XCB based drawing context using pango and cairo
+    #[derive(Clone, Debug)]
     pub struct XcbDrawContext {
         ctx: cairo::Context,
         font: Option<pango::FontDescription>,

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -88,7 +88,10 @@ pub fn new_xcb_backed_window_manager(
     hooks: Vec<Box<dyn Hook>>,
 ) -> crate::Result<WindowManager> {
     let conn = XcbConnection::new(Api::new()?)?;
-    Ok(WindowManager::init(config, Box::new(conn), hooks))
+    let mut wm = WindowManager::new(config, Box::new(conn), hooks);
+    wm.init();
+
+    Ok(wm)
 }
 
 /**

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -29,13 +29,13 @@ use std::str::FromStr;
 
 const WM_NAME: &str = "penrose";
 
-#[derive(Clone, Debug)]
 /**
  * Handles communication with an X server via the XCB library.
  *
  * XcbConnection is a minimal implementation that does not make use of the full asyc capabilities
  * of the underlying C XCB library.
  **/
+#[derive(Clone, Debug)]
 pub struct XcbConnection<X: XcbApi> {
     api: X,
     check_win: WinId,

--- a/tests/hook_tests.rs
+++ b/tests/hook_tests.rs
@@ -107,7 +107,8 @@ macro_rules! hook_test {
                 events,
                 vec![],
             );
-            let mut wm = WindowManager::init(config, Box::new(conn), hooks);
+            let mut wm = WindowManager::new(config, Box::new(conn), hooks);
+            wm.init();
             wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
             drop(wm);
 

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -13,7 +13,7 @@ use penrose::{
     },
     PenroseError,
 };
-use serde_json;
+
 use std::collections::HashMap;
 
 mod common;

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -1,0 +1,203 @@
+// Check that restoring from serialised state is working
+#[macro_use]
+extern crate penrose;
+
+use penrose::{
+    core::{
+        config::Config,
+        data_types::WinId,
+        layout::{floating, side_stack, LayoutFunc},
+        manager::WindowManager,
+        screen::Screen,
+        xconnection::{MockXConn, StubXConn, XEvent},
+    },
+    PenroseError,
+};
+use serde_json;
+use std::collections::HashMap;
+
+mod common;
+
+struct EarlyExitConn {
+    on_init: bool,
+    valid_clients: bool,
+}
+impl StubXConn for EarlyExitConn {
+    fn mock_current_outputs(&self) -> Vec<Screen> {
+        if self.on_init {
+            panic!("panic on call to current_outputs");
+        }
+
+        vec![common::simple_screen(0), common::simple_screen(1)]
+    }
+
+    fn mock_wait_for_event(&self) -> Option<XEvent> {
+        if !self.on_init {
+            panic!("panic on call to wait_for_event");
+        }
+
+        None
+    }
+
+    fn mock_query_for_active_windows(&self) -> Vec<WinId> {
+        if self.valid_clients {
+            vec![1, 2, 3]
+        } else {
+            vec![]
+        }
+    }
+}
+
+fn layout_funcs() -> HashMap<&'static str, LayoutFunc> {
+    map! {
+        "[side]" => side_stack as LayoutFunc,
+        "[----]" => floating as LayoutFunc,
+    }
+}
+
+fn get_wm() -> WindowManager {
+    // Seeding the MockXConn with events so that we should end up with:
+    //   - clients 1 on workspace 0
+    //   - client 2 & 3 on workspace 1
+    //   - focus on client 2
+    //   - screen 0 holding workspace 1
+    //   - screen 1 holding workspace 0
+    let conn = MockXConn::new(
+        vec![common::simple_screen(0), common::simple_screen(1)],
+        vec![
+            XEvent::MapRequest {
+                id: 1,
+                ignore: false,
+            },
+            XEvent::KeyPress(common::WORKSPACE_CHANGE_CODE),
+            XEvent::MapRequest {
+                id: 2,
+                ignore: false,
+            },
+            XEvent::MapRequest {
+                id: 3,
+                ignore: false,
+            },
+            XEvent::KeyPress(common::FOCUS_CHANGE_CODE),
+            XEvent::KeyPress(common::EXIT_CODE),
+        ],
+        vec![],
+    );
+
+    let mut wm = WindowManager::new(Config::default(), Box::new(conn), vec![]);
+    wm.init();
+
+    wm
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_windowmanager_can_be_serialized() {
+    let wm = get_wm();
+    let as_json = serde_json::to_string(&wm);
+    assert!(as_json.is_ok());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_windowmanager_can_be_deserialized() {
+    let wm = get_wm();
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let unchecked_wm: Result<WindowManager, serde_json::Error> = serde_json::from_str(&as_json);
+    assert!(unchecked_wm.is_ok());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[should_panic(
+    expected = "StubConn is not usable as a real XConn impl: call hydrate_and_init instead"
+)]
+fn serde_running_without_hydrating_panics() {
+    let wm = get_wm();
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let mut unchecked_wm: WindowManager = serde_json::from_str(&as_json).unwrap();
+    unchecked_wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_hydrating_when_x_state_is_wrong_errors() {
+    let mut wm = get_wm();
+    wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let mut unchecked_wm: WindowManager = serde_json::from_str(&as_json).unwrap();
+    let res = unchecked_wm.hydrate_and_init(
+        Box::new(EarlyExitConn {
+            on_init: true,
+            valid_clients: false,
+        }),
+        vec![],
+        layout_funcs(),
+    );
+
+    match res {
+        Ok(_) => panic!("this should have caused a errored"),
+        Err(e) => match e {
+            PenroseError::MissingClientIds(ids) => assert_eq!(&ids, &[1, 2, 3]),
+            _ => panic!("unexpected Error type from hydration"),
+        },
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[should_panic(
+    expected = "StubConn is not usable as a real XConn impl: call hydrate_and_init instead"
+)]
+fn serde_running_init_directly_panics() {
+    let wm = get_wm();
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let mut unchecked_wm: WindowManager = serde_json::from_str(&as_json).unwrap();
+    unchecked_wm.init();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[should_panic(expected = "panic on call to current_outputs")]
+fn serde_hydrate_and_init_works_with_serialized_state() {
+    let mut wm = get_wm();
+    wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let mut unchecked_wm: WindowManager = serde_json::from_str(&as_json).unwrap();
+
+    // Should panic on the call to current_outputs in WindowManager::init()
+    unchecked_wm
+        .hydrate_and_init(
+            Box::new(EarlyExitConn {
+                on_init: true,
+                valid_clients: true,
+            }),
+            vec![],
+            layout_funcs(),
+        )
+        .unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+#[should_panic(expected = "panic on call to wait_for_event")]
+fn serde_running_after_hydration_works() {
+    let mut wm = get_wm();
+    wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
+    let as_json = serde_json::to_string(&wm).unwrap();
+    let mut unchecked_wm: WindowManager = serde_json::from_str(&as_json).unwrap();
+
+    unchecked_wm
+        .hydrate_and_init(
+            Box::new(EarlyExitConn {
+                on_init: false,
+                valid_clients: true,
+            }),
+            vec![],
+            layout_funcs(),
+        )
+        .unwrap();
+
+    // Should panic on the call to XConn::wait_for_event()
+    unchecked_wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
+}


### PR DESCRIPTION
This adds serde derives for most of the data structures in penrose, with some additional logic and changes being required to make this work with non-serializable state (such as layout functions and `dyn` trait objects).

Other than some minimal testing of the methods with `serde_json` not much has been checked yet, and the state validation needs to be implemented in `hydrate_and_init`.