### PR TITLE
Make WindowManager generic over XConn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose
 
   rustfmt:
     name: Ensure rustfmt is happy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta, nightly]
+        features: ["xcb,xcb_draw", "xcb,xcb_draw,serde"]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,7 +33,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
 
     - name: Run tests
-      run: cargo test --all-features --verbose
+      run: cargo test --features ${{ matrix.features }} --verbose
 
   rustfmt:
     name: Ensure rustfmt is happy

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check-all:
 
 .PHONY: doc
 doc:
-	cargo doc --open &
+	cargo doc --all-features --open &
 
 .PHONY: examples
 examples:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build:
 build-release:
 	cargo lint && cargo build --release
 
+.PHONY: check
+check:
+	cargo clippy --workspace --all-targets --all-features --examples --tests
+
 .PHONY: check-all
 check-all:
 	cargo fmt --all -- --check

--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -43,7 +43,7 @@ fn bar_draw() -> Result<()> {
     let highlight = BLUE;
     let empty_ws = GREY;
     let mut bar = dwm_bar(
-        Box::new(XcbDraw::new()?),
+        XcbDraw::new()?,
         HEIGHT,
         &style,
         highlight,

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -11,7 +11,7 @@ use penrose::{
     core::{
         config::Config,
         helpers::{index_selectors, spawn_for_output},
-        hooks::Hook,
+        hooks::Hooks,
         layout::{bottom_stack, side_stack, Layout, LayoutConf},
     },
     xcb::new_xcb_backed_window_manager,
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
     config.layouts(my_layouts());
     let sp = Scratchpad::new("st", 0.8, 0.8);
 
-    let hooks: Vec<Box<dyn Hook>> = vec![
+    let hooks: Hooks<_> = vec![
         LayoutSymbolAsRootName::new(),
         RemoveEmptyWorkspaces::new(config.workspaces.clone()),
         DefaultWorkspace::new("1term", "[side]", vec!["st"]),

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -49,8 +49,8 @@ fn main() -> Result<()> {
     };
 
     let mouse_bindings = gen_mousebindings! {
-        Press Right + [Meta] => |wm: &mut WindowManager, _: &MouseEvent| wm.cycle_workspace(Forward),
-        Press Left + [Meta] => |wm: &mut WindowManager, _: &MouseEvent| wm.cycle_workspace(Backward)
+        Press Right + [Meta] => |wm: &mut WindowManager<_>, _: &MouseEvent| wm.cycle_workspace(Forward),
+        Press Left + [Meta] => |wm: &mut WindowManager<_>, _: &MouseEvent| wm.cycle_workspace(Backward)
     };
 
     let mut wm = new_xcb_backed_window_manager(config, hooks)?;

--- a/src/contrib/actions.rs
+++ b/src/contrib/actions.rs
@@ -1,7 +1,7 @@
 //! Additional helper functions and actions for use with penrose.
 use crate::core::{
     bindings::FireAndForget, client::Client, helpers::spawn, layout::Layout,
-    manager::WindowManager, ring::Selector, workspace::Workspace,
+    manager::WindowManager, ring::Selector, workspace::Workspace, xconnection::XConn,
 };
 
 /**
@@ -11,11 +11,11 @@ use crate::core::{
  * already exist then simply switch focus to it. This action is most useful when combined with the
  * DefaultWorkspace hook that allows for auto populating named Workspaces when first focusing them.
  */
-pub fn create_or_switch_to_workspace(
+pub fn create_or_switch_to_workspace<X: XConn>(
     get_name: fn() -> String,
     layouts: Vec<Layout>,
-) -> FireAndForget {
-    Box::new(move |wm: &mut WindowManager| {
+) -> FireAndForget<X> {
+    Box::new(move |wm: &mut WindowManager<X>| {
         let name = &get_name();
         let cond = |ws: &Workspace| ws.name() == name;
         let sel = Selector::Condition(&cond);
@@ -32,8 +32,8 @@ pub fn create_or_switch_to_workspace(
  * that are based on the program you want to work with rather than having to
  * remember where things are running.
  */
-pub fn focus_or_spawn(class: String, command: String) -> FireAndForget {
-    Box::new(move |wm: &mut WindowManager| {
+pub fn focus_or_spawn<X: XConn>(class: String, command: String) -> FireAndForget<X> {
+    Box::new(move |wm: &mut WindowManager<X>| {
         let cond = |c: &Client| c.class() == class;
         if let Some(client) = wm.client(&Selector::Condition(&cond)) {
             let workspace = client.workspace();

--- a/src/core/bindings.rs
+++ b/src/core/bindings.rs
@@ -12,16 +12,16 @@ use std::{collections::HashMap, convert::TryFrom};
 use strum::{EnumIter, IntoEnumIterator};
 
 /// Some action to be run by a user key binding
-pub type FireAndForget = Box<dyn FnMut(&mut WindowManager)>;
+pub type FireAndForget<X> = Box<dyn FnMut(&mut WindowManager<X>)>;
 
 /// An action to be run in response to a mouse event
-pub type MouseEventHandler = Box<dyn FnMut(&mut WindowManager, &MouseEvent)>;
+pub type MouseEventHandler<X> = Box<dyn FnMut(&mut WindowManager<X>, &MouseEvent)>;
 
 /// User defined key bindings
-pub type KeyBindings = HashMap<KeyCode, FireAndForget>;
+pub type KeyBindings<X> = HashMap<KeyCode, FireAndForget<X>>;
 
 /// User defined mouse bindings
-pub type MouseBindings = HashMap<(MouseEventKind, MouseState), MouseEventHandler>;
+pub type MouseBindings<X> = HashMap<(MouseEventKind, MouseState), MouseEventHandler<X>>;
 
 pub(crate) type CodeMap = HashMap<String, u8>;
 

--- a/src/core/hooks.rs
+++ b/src/core/hooks.rs
@@ -3,10 +3,11 @@ use crate::core::{
     client::Client,
     data_types::{Region, WinId},
     manager::WindowManager,
+    xconnection::XConn,
 };
 
 /// Utility type for defining hooks in your penrose configuration.
-pub type Hooks = Vec<Box<dyn Hook>>;
+pub type Hooks<X> = Vec<Box<dyn Hook<X>>>;
 
 /**
  * impls of Hook can be registered to receive events during WindowManager operation. Each hook
@@ -18,7 +19,7 @@ pub type Hooks = Vec<Box<dyn Hook>>;
  * triggers and that, where possible, support for other Hooks running from the same triggers is
  * possible.
  */
-pub trait Hook {
+pub trait Hook<X: XConn> {
     /**
      * Called when a new Client has been created and penrose state has been initialised
      * but before the client has been added to the active Workspace and before any Layouts
@@ -27,13 +28,13 @@ pub trait Hook {
      * not passed back to penrose. If the hook takes ownership of the client, it is responsible
      * ensuring that it is unmapped.
      */
-    fn new_client(&mut self, _wm: &mut WindowManager, _c: &mut Client) {}
+    fn new_client(&mut self, _wm: &mut WindowManager<X>, _c: &mut Client) {}
 
     /**
      * Called when a Client is removed from the WindowManager, either through a user initiated
      * kill_client action or the Client exiting itself.
      */
-    fn remove_client(&mut self, _wm: &mut WindowManager, _id: WinId) {}
+    fn remove_client(&mut self, _wm: &mut WindowManager<X>, _id: WinId) {}
 
     /**
      * Called whenever something updates the WM_NAME or _NET_WM_NAME property on a window.
@@ -41,7 +42,7 @@ pub trait Hook {
      */
     fn client_name_updated(
         &mut self,
-        _wm: &mut WindowManager,
+        _wm: &mut WindowManager<X>,
         _id: WinId,
         _name: &str,
         _is_root: bool,
@@ -51,7 +52,7 @@ pub trait Hook {
     /**
      * Called whenever an existing [Client] is added to a [Workspace][crate::core::workspace::Workspace]
      */
-    fn client_added_to_workspace(&mut self, _wm: &mut WindowManager, _id: WinId, _wix: usize) {}
+    fn client_added_to_workspace(&mut self, _wm: &mut WindowManager<X>, _id: WinId, _wix: usize) {}
 
     /**
      * Called after a Layout is applied to the active Workspace.
@@ -61,7 +62,7 @@ pub trait Hook {
      */
     fn layout_applied(
         &mut self,
-        _wm: &mut WindowManager,
+        _wm: &mut WindowManager<X>,
         _workspace_index: usize,
         _screen_index: usize,
     ) {
@@ -75,7 +76,7 @@ pub trait Hook {
      */
     fn layout_change(
         &mut self,
-        _wm: &mut WindowManager,
+        _wm: &mut WindowManager<X>,
         _workspace_index: usize,
         _screen_index: usize,
     ) {
@@ -88,7 +89,7 @@ pub trait Hook {
      */
     fn workspace_change(
         &mut self,
-        _wm: &mut WindowManager,
+        _wm: &mut WindowManager<X>,
         _previous_workspace: usize,
         _new_workspace: usize,
     ) {
@@ -97,26 +98,26 @@ pub trait Hook {
     /**
      * Called when there has been a change to the WindowManager workspace list.
      */
-    fn workspaces_updated(&mut self, _wm: &mut WindowManager, _names: &[&str], _active: usize) {}
+    fn workspaces_updated(&mut self, _wm: &mut WindowManager<X>, _names: &[&str], _active: usize) {}
 
     /**
      * Called after focus moves to a new Screen.
      * Argument is a index into the WindowManager screen array (internal data structure that supports
      * indexing) for the new Screen.
      */
-    fn screen_change(&mut self, _wm: &mut WindowManager, _screen_index: usize) {}
+    fn screen_change(&mut self, _wm: &mut WindowManager<X>, _screen_index: usize) {}
 
     /**
      * Called when there has been a change to the WindowManager workspace list.
      */
-    fn screens_updated(&mut self, _wm: &mut WindowManager, _dimensions: &[Region]) {}
+    fn screens_updated(&mut self, _wm: &mut WindowManager<X>, _dimensions: &[Region]) {}
 
     /**
      * Called after a new Client gains focus.
      * Argument is the focused Client ID which can be used to fetch the internal Client state if
      * needed.
      */
-    fn focus_change(&mut self, _wm: &mut WindowManager, _id: WinId) {}
+    fn focus_change(&mut self, _wm: &mut WindowManager<X>, _id: WinId) {}
 
     /**
      * Called at the end of the main WindowManager event loop once each XEvent has been handled.
@@ -124,10 +125,10 @@ pub trait Hook {
      * Usefull if you want to ensure that all other event processing has taken place before you
      * take action in response to another hook.
      */
-    fn event_handled(&mut self, _wm: &mut WindowManager) {}
+    fn event_handled(&mut self, _wm: &mut WindowManager<X>) {}
 
     /**
      * Called once at window manager startup
      */
-    fn startup(&mut self, _wm: &mut WindowManager) {}
+    fn startup(&mut self, _wm: &mut WindowManager<X>) {}
 }

--- a/src/core/hooks.rs
+++ b/src/core/hooks.rs
@@ -10,13 +10,15 @@ use crate::core::{
 pub type Hooks<X> = Vec<Box<dyn Hook<X>>>;
 
 /**
- * impls of Hook can be registered to receive events during WindowManager operation. Each hook
- * point is documented as individual methods detailing when and how they will be called. All Hook
- * impls will be called for each trigger so the required methods all provide a no-op default
- * implementation that must be overriden to provide functionality. Hooks may 'subscribe' to
+ * User defined functionality triggered by [WindowManager] actions.
+ *
+ * impls of [Hook] can be registered to receive events during [WindowManager] operation. Each hook
+ * point is documented as individual methods detailing when and how they will be called. All
+ * registered hooks will be called for each trigger so the required methods all provide a no-op
+ * default implementation that must be overriden to provide functionality. Hooks may 'subscribe' to
  * multiple triggers to implement more complex behaviours and may store additional state. Care
- * should be taken when writing Hook impls to ensure that infinite loops are not created by nested
- * triggers and that, where possible, support for other Hooks running from the same triggers is
+ * should be taken when writing [Hook] impls to ensure that infinite loops are not created by nested
+ * triggers and that, where possible, support for other hooks running from the same triggers is
  * possible.
  */
 pub trait Hook<X: XConn> {

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -143,6 +143,7 @@ impl Layout {
 
     // NOTE: Used when rehydrating from serde based deserialization. The layout will panic if
     //       used before setting the LayoutFunc. See [WindowManager::hydrate_and_init]
+    #[cfg(feature = "serde")]
     pub(crate) fn set_layout_function(&mut self, f: LayoutFunc) {
         self.f = Some(f);
     }

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -6,9 +6,9 @@
 #[macro_export]
 macro_rules! run_external {
     ($cmd:tt) => {{
-        Box::new(move |_: &mut $crate::core::manager::WindowManager| {
+        Box::new(move |_: &mut $crate::core::manager::WindowManager<_>| {
             $crate::core::helpers::spawn($cmd);
-        }) as $crate::core::bindings::FireAndForget
+        }) as $crate::core::bindings::FireAndForget<_>
     }};
 }
 
@@ -16,15 +16,15 @@ macro_rules! run_external {
 #[macro_export]
 macro_rules! run_internal {
     ($func:ident) => {
-        Box::new(|wm: &mut $crate::core::manager::WindowManager| {
+        Box::new(|wm: &mut $crate::core::manager::WindowManager<_>| {
             wm.$func();
-        }) as $crate::core::bindings::FireAndForget
+        }) as $crate::core::bindings::FireAndForget<_>
     };
 
     ($func:ident, $($arg:expr),+) => {
-        Box::new(move |wm: &mut $crate::core::manager::WindowManager| {
+        Box::new(move |wm: &mut $crate::core::manager::WindowManager<_>| {
             wm.$func($($arg),+);
-        }) as $crate::core::bindings::FireAndForget
+        }) as $crate::core::bindings::FireAndForget<_>
     };
 }
 
@@ -138,7 +138,7 @@ macro_rules! gen_mousebindings {
                 let kind = $crate::core::bindings::MouseEventKind::$kind;
                 _map.insert(
                     (kind, state),
-                    Box::new($action) as $crate::core::bindings::MouseEventHandler
+                    Box::new($action) as $crate::core::bindings::MouseEventHandler<_>
                 );
             )+
 

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -6,7 +6,6 @@ use crate::{
         config::Config,
         data_types::{Change, Point, Region, WinId},
         hooks::Hooks,
-        layout::LayoutFunc,
         ring::{Direction, InsertPoint, Ring, Selector},
         screen::Screen,
         workspace::Workspace,
@@ -14,6 +13,9 @@ use crate::{
     },
     Result,
 };
+
+#[cfg(feature = "serde")]
+use crate::core::layout::LayoutFunc;
 
 use nix::sys::signal::{signal, SigHandler, Signal};
 
@@ -115,11 +117,13 @@ impl<X: XConn> WindowManager<X> {
     }
 
     /// Restore missing state following serde deserialization
+    #[cfg(feature = "serde")]
     pub fn hydrate_and_init(
         &mut self,
         hooks: Hooks<X>,
         layout_funcs: HashMap<&str, LayoutFunc>,
     ) -> Result<()> {
+        self.conn.hydrate()?;
         self.hooks.set(hooks);
         self.workspaces
             .iter_mut()

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -3,13 +3,15 @@ use crate::{
         client::Client,
         data_types::{Region, WinId},
         layout::LayoutConf,
-        manager::WindowManager,
         screen::Screen,
         workspace::{ArrangeActions, Workspace},
         xconnection::{Atom, XConn},
     },
-    PenroseError, Result,
+    Result,
 };
+
+#[cfg(feature = "serde")]
+use crate::{core::manager::WindowManager, PenroseError};
 
 use std::collections::HashMap;
 
@@ -177,6 +179,7 @@ pub(super) fn apply_arrange_actions<X: XConn>(
     }
 }
 
+#[cfg(feature = "serde")]
 pub(super) fn validate_hydrated_wm_state<X: XConn>(wm: &mut WindowManager<X>) -> Result<()> {
     // If the current clients known to the X server aren't what we have in the client_map
     // then we can't proceed any further

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1,13 +1,13 @@
 //! A Workspace is a set of displayed clients and a set of Layouts for arranging them
-use crate::{
-    core::{
-        client::Client,
-        data_types::{Change, Region, ResizeAction, WinId},
-        layout::{Layout, LayoutConf, LayoutFunc},
-        ring::{Direction, InsertPoint, Ring, Selector},
-    },
-    PenroseError, Result,
+use crate::core::{
+    client::Client,
+    data_types::{Change, Region, ResizeAction, WinId},
+    layout::{Layout, LayoutConf},
+    ring::{Direction, InsertPoint, Ring, Selector},
 };
+
+#[cfg(feature = "serde")]
+use crate::{core::layout::LayoutFunc, PenroseError, Result};
 
 use std::collections::HashMap;
 
@@ -63,6 +63,7 @@ impl Workspace {
         self.name = name.into();
     }
 
+    #[cfg(feature = "serde")]
     pub(crate) fn restore_layout_functions(
         &mut self,
         layout_funcs: &HashMap<&str, LayoutFunc>,

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -296,6 +296,10 @@ pub enum XEvent {
  * windowing system but X idioms and high level event types / client interations are assumed.
  **/
 pub trait XConn {
+    /// Hydrate this XConn to restore internal state following serde deserialization
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()>;
+
     /// Flush pending actions to the X event loop
     fn flush(&self) -> bool;
 
@@ -415,6 +419,12 @@ pub trait XConn {
  * make writing real impls more error prone if and when new methods are added to the trait.
  */
 pub trait StubXConn {
+    /// Mocked version of hydrate
+    #[cfg(feature = "serde")]
+    fn mock_hydrate(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     /// Mocked version of flush
     fn mock_flush(&self) -> bool {
         true
@@ -524,6 +534,11 @@ impl<T> XConn for T
 where
     T: StubXConn,
 {
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()> {
+        self.mock_hydrate()
+    }
+
     fn flush(&self) -> bool {
         self.mock_flush()
     }

--- a/src/draw/bar/mod.rs
+++ b/src/draw/bar/mod.rs
@@ -8,7 +8,7 @@ pub use statusbar::{Position, StatusBar};
 pub use widgets::{ActiveWindowName, CurrentLayout, RootWindowName, Text, Workspaces};
 
 use crate::{
-    core::hooks::Hook,
+    core::{hooks::Hook, xconnection::XConn},
     draw::{Color, Draw, DrawContext, Result, TextStyle},
 };
 
@@ -21,7 +21,7 @@ const MAX_ACTIVE_WINDOW_CHARS: usize = 80;
  * triggers: the status bar itself will handle passing through triggers and check for required
  * updates to the UI.
  */
-pub trait Widget: Hook {
+pub trait Widget<X: XConn>: Hook<X> {
     /**
      * Render the current state of the widget to the status bar window.
      */
@@ -50,14 +50,14 @@ pub trait Widget: Hook {
 
 /// Create a default dwm style status bar that displays content pulled from the
 /// WM_NAME property of the root window.
-pub fn dwm_bar<Ctx: DrawContext>(
+pub fn dwm_bar<Ctx: DrawContext, X: XConn + 'static>(
     drw: Box<dyn Draw<Ctx = Ctx>>,
     height: usize,
     style: &TextStyle,
     highlight: impl Into<Color>,
     empty_ws: impl Into<Color>,
     workspaces: Vec<impl Into<String>>,
-) -> Result<StatusBar<Ctx>> {
+) -> Result<StatusBar<Ctx, X>> {
     let highlight = highlight.into();
     let workspaces: Vec<String> = workspaces.into_iter().map(|w| w.into()).collect();
 

--- a/src/draw/bar/mod.rs
+++ b/src/draw/bar/mod.rs
@@ -21,34 +21,26 @@ const MAX_ACTIVE_WINDOW_CHARS: usize = 80;
  * HookableWidgets should _not_ be manually registered as hooks: they will be automatically
  * registered by the [StatusBar] containing them on startup.
  */
-pub trait HookableWidget<C, X>: Hook<X> + Widget<C>
+pub trait HookableWidget<X>: Hook<X> + Widget
 where
-    C: DrawContext,
     X: XConn,
 {
 }
 
-impl<C, X, T> HookableWidget<C, X> for T
+// Blanket implementation for anything that implements both Hook and Widget
+impl<X, T> HookableWidget<X> for T
 where
-    C: DrawContext,
     X: XConn,
-    T: Hook<X> + Widget<C>,
+    T: Hook<X> + Widget,
 {
 }
 
-/**
- * A status bar widget that can be rendered using a [DrawContext]
- */
-pub trait Widget<C>
-where
-    C: DrawContext,
-{
-    /**
-     * Render the current state of the widget to the status bar window.
-     */
+/// A status bar widget that can be rendered using a [DrawContext]
+pub trait Widget {
+    /// Render the current state of the widget to the status bar window.
     fn draw(
         &mut self,
-        ctx: &mut C,
+        ctx: &mut dyn DrawContext,
         screen: usize,
         screen_has_focus: bool,
         w: f64,
@@ -56,7 +48,7 @@ where
     ) -> Result<()>;
 
     /// Current required width and height for this widget due to its content
-    fn current_extent(&mut self, ctx: &mut C, h: f64) -> Result<(f64, f64)>;
+    fn current_extent(&mut self, ctx: &mut dyn DrawContext, h: f64) -> Result<(f64, f64)>;
 
     /// Does this widget currently require re-rendering? (should be updated when 'draw' is called)
     fn require_draw(&self) -> bool;

--- a/src/draw/bar/statusbar.rs
+++ b/src/draw/bar/statusbar.rs
@@ -30,7 +30,7 @@ where
 {
     drw: D,
     position: Position,
-    widgets: Vec<Box<dyn HookableWidget<C, X>>>,
+    widgets: Vec<Box<dyn HookableWidget<X>>>,
     screens: Vec<(WinId, f64)>, // window and width
     hpx: usize,
     h: f64,
@@ -70,7 +70,7 @@ where
         h: usize,
         bg: impl Into<Color>,
         fonts: &[&str],
-        widgets: Vec<Box<dyn HookableWidget<C, X>>>,
+        widgets: Vec<Box<dyn HookableWidget<X>>>,
     ) -> Result<Self> {
         let mut bar = Self {
             drw,

--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -113,6 +113,10 @@ impl Api {
         Ok(())
     }
 
+    pub(crate) fn known_atoms(&self) -> &HashMap<Atom, u32> {
+        &self.atoms
+    }
+
     pub(crate) fn conn(&self) -> &xcb::Connection {
         &self.conn
     }

--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -12,8 +12,16 @@ use strum::*;
 
 use std::{collections::HashMap, fmt, str::FromStr};
 
+#[cfg(feature = "serde")]
+fn default_conn() -> xcb::Connection {
+    let (conn, _) = xcb::Connection::connect(None).unwrap();
+    conn
+}
+
 /// A connection to the X server using the XCB C API
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Api {
+    #[cfg_attr(feature = "serde", serde(skip, default = "default_conn"))]
     conn: xcb::Connection,
     root: WinId,
     check_win: WinId,
@@ -55,35 +63,54 @@ impl Api {
     /// Connect to the X server using the XCB API
     pub fn new() -> Result<Self> {
         let (conn, _) = xcb::Connection::connect(None)?;
-        let root = match conn.get_setup().roots().next() {
+        let mut api = Self {
+            conn,
+            root: 0,
+            check_win: 0,
+            randr_base: 0,
+            atoms: HashMap::new(),
+        };
+        api.init()?;
+
+        Ok(api)
+    }
+
+    fn init(&mut self) -> Result<()> {
+        self.root = match self.conn.get_setup().roots().next() {
             Some(r) => r.root(),
             None => return Err(XcbError::NoScreens),
         };
-        let randr_base = conn
+        self.randr_base = self
+            .conn
             .get_extension_data(&mut xcb::randr::id())
             .ok_or_else(|| XcbError::Randr("unable to fetch extension data".into()))?
             .first_event();
 
-        let check_win = conn.generate_id();
-        xcb::create_window(&conn, 0, check_win, root, 0, 0, 1, 1, 0, 0, 0, &[]);
-        conn.flush();
+        self.check_win = self.conn.generate_id();
+        xcb::create_window(
+            &self.conn,
+            0,
+            self.check_win,
+            self.root,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            &[],
+        );
+        self.conn.flush();
 
-        let mut api = Self {
-            conn,
-            root,
-            check_win,
-            randr_base,
-            atoms: HashMap::new(),
-        };
-
-        api.atoms = Atom::iter()
+        self.atoms = Atom::iter()
             .map(|atom| {
-                let val = api.atom(atom.as_ref())?;
+                let val = self.atom(atom.as_ref())?;
                 Ok((atom, val))
             })
             .collect::<Result<HashMap<_, _>>>()?;
 
-        Ok(api)
+        Ok(())
     }
 
     pub(crate) fn conn(&self) -> &xcb::Connection {
@@ -116,6 +143,11 @@ impl Api {
 }
 
 impl XcbApi for Api {
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()> {
+        self.init()
+    }
+
     // xcb docs: https://www.mankier.com/3/xcb_intern_atom
     fn atom(&self, name: &str) -> Result<u32> {
         if let Ok(known) = Atom::from_str(name) {

--- a/src/xcb/draw.rs
+++ b/src/xcb/draw.rs
@@ -5,217 +5,216 @@
  * This is a reference implementation and requires that you have the relevant C dependencies
  * installed on your system for it to work.
  */
-#[cfg(feature = "xcb_draw")]
-#[doc(inline)]
-pub use inner::{XcbDraw, XcbDrawContext};
+use crate::{
+    core::{
+        data_types::{PropVal, Region, WinId, WinType},
+        xconnection::Atom,
+    },
+    draw::{Color, Draw, DrawContext, DrawError, Result},
+    xcb::{XcbApi, XcbError},
+};
 
-#[cfg(feature = "xcb_draw")]
-mod inner {
-    use crate::{
-        core::{
-            data_types::{PropVal, Region, WinId, WinType},
-            xconnection::Atom,
-        },
-        draw::{Color, Draw, DrawContext, DrawError, Result},
-        xcb::{XcbApi, XcbError},
-    };
+use pangocairo::functions::{create_layout, show_layout};
 
-    use pangocairo::functions::{create_layout, show_layout};
+use std::collections::HashMap;
 
-    use std::collections::HashMap;
+fn pango_layout(ctx: &cairo::Context) -> Result<pango::Layout> {
+    Ok(create_layout(ctx).ok_or_else(|| XcbError::Pango("unable to create layout".into()))?)
+}
 
-    fn pango_layout(ctx: &cairo::Context) -> Result<pango::Layout> {
-        Ok(create_layout(ctx).ok_or_else(|| XcbError::Pango("unable to create layout".into()))?)
+/// An XCB based [Draw] implementation backed by pango and cairo
+#[derive(Clone, Debug)]
+pub struct XcbDraw {
+    api: crate::xcb::Api,
+    fonts: HashMap<String, pango::FontDescription>,
+    surfaces: HashMap<WinId, cairo::XCBSurface>,
+}
+
+impl XcbDraw {
+    /// Create a new empty [XcbDraw]. Fails if unable to connect to the X server
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            api: crate::xcb::Api::new()?,
+            fonts: HashMap::new(),
+            surfaces: HashMap::new(),
+        })
+    }
+}
+
+impl Drop for XcbDraw {
+    fn drop(&mut self) {
+        self.surfaces.keys().for_each(|&id| self.destroy_window(id));
+    }
+}
+
+impl Draw for XcbDraw {
+    type Ctx = XcbDrawContext;
+
+    fn new_window(&mut self, ty: WinType, r: Region, managed: bool) -> Result<WinId> {
+        let (_, _, w, h) = r.values();
+        let id = self.api.create_window(ty, r, managed)?;
+        let xcb_screen = self.api.screen(0)?;
+        let depth = self.api.get_depth(&xcb_screen)?;
+        let mut visualtype = self.api.get_visual_type(&depth)?;
+
+        let surface = unsafe {
+            let conn_ptr = self.api.conn().get_raw_conn() as *mut cairo_sys::xcb_connection_t;
+
+            cairo::XCBSurface::create(
+                &cairo::XCBConnection::from_raw_none(conn_ptr),
+                &cairo::XCBDrawable(id),
+                &cairo::XCBVisualType::from_raw_none(
+                    &mut visualtype.base as *mut xcb::ffi::xcb_visualtype_t
+                        as *mut cairo_sys::xcb_visualtype_t,
+                ),
+                w as i32,
+                h as i32,
+            )?
+        };
+
+        surface.set_size(w as i32, h as i32).unwrap();
+        self.surfaces.insert(id, surface);
+
+        Ok(id)
     }
 
-    /// An XCB based [Draw] implementation backed by pango and cairo
-    #[derive(Clone, Debug)]
-    pub struct XcbDraw {
-        api: crate::xcb::Api,
-        fonts: HashMap<String, pango::FontDescription>,
-        surfaces: HashMap<WinId, cairo::XCBSurface>,
+    fn screen_sizes(&self) -> Result<Vec<Region>> {
+        Ok(self.api.screen_sizes()?)
     }
 
-    impl XcbDraw {
-        /// Create a new empty [XcbDraw]. Fails if unable to connect to the X server
-        pub fn new() -> Result<Self> {
-            Ok(Self {
-                api: crate::xcb::Api::new()?,
-                fonts: HashMap::new(),
-                surfaces: HashMap::new(),
-            })
-        }
+    fn register_font(&mut self, font_name: &str) {
+        self.fonts.insert(
+            font_name.into(),
+            pango::FontDescription::from_string(font_name),
+        );
     }
 
-    impl Draw for XcbDraw {
-        type Ctx = XcbDrawContext;
+    fn context_for(&self, id: WinId) -> Result<Self::Ctx> {
+        let ctx = cairo::Context::new(
+            self.surfaces
+                .get(&id)
+                .ok_or(XcbError::UnintialisedSurface(id))?,
+        );
 
-        fn new_window(&mut self, ty: WinType, r: Region, managed: bool) -> Result<WinId> {
-            let (_, _, w, h) = r.values();
-            let id = self.api.create_window(ty, r, managed)?;
-            let xcb_screen = self.api.screen(0)?;
-            let depth = self.api.get_depth(&xcb_screen)?;
-            let mut visualtype = self.api.get_visual_type(&depth)?;
-
-            let surface = unsafe {
-                let conn_ptr = self.api.conn().get_raw_conn() as *mut cairo_sys::xcb_connection_t;
-
-                cairo::XCBSurface::create(
-                    &cairo::XCBConnection::from_raw_none(conn_ptr),
-                    &cairo::XCBDrawable(id),
-                    &cairo::XCBVisualType::from_raw_none(
-                        &mut visualtype.base as *mut xcb::ffi::xcb_visualtype_t
-                            as *mut cairo_sys::xcb_visualtype_t,
-                    ),
-                    w as i32,
-                    h as i32,
-                )?
-            };
-
-            surface.set_size(w as i32, h as i32).unwrap();
-            self.surfaces.insert(id, surface);
-
-            Ok(id)
-        }
-
-        fn screen_sizes(&self) -> Result<Vec<Region>> {
-            Ok(self.api.screen_sizes()?)
-        }
-
-        fn register_font(&mut self, font_name: &str) {
-            self.fonts.insert(
-                font_name.into(),
-                pango::FontDescription::from_string(font_name),
-            );
-        }
-
-        fn context_for(&self, id: WinId) -> Result<Self::Ctx> {
-            let ctx = cairo::Context::new(
-                self.surfaces
-                    .get(&id)
-                    .ok_or(XcbError::UnintialisedSurface(id))?,
-            );
-
-            Ok(Self::Ctx {
-                ctx,
-                font: None,
-                fonts: self.fonts.clone(),
-            })
-        }
-
-        fn flush(&self, id: WinId) {
-            if let Some(s) = self.surfaces.get(&id) {
-                s.flush()
-            };
-            self.map_window(id);
-            self.api.flush();
-        }
-
-        fn map_window(&self, id: WinId) {
-            self.api.map_window(id);
-        }
-
-        fn unmap_window(&self, id: WinId) {
-            self.api.unmap_window(id);
-        }
-
-        fn destroy_window(&self, id: WinId) {
-            self.api.destroy_window(id);
-        }
-
-        fn replace_prop(&self, id: WinId, prop: Atom, val: PropVal<'_>) {
-            self.api.replace_prop(id, prop, val);
-        }
+        Ok(Self::Ctx {
+            ctx,
+            font: None,
+            fonts: self.fonts.clone(),
+        })
     }
 
-    /// An XCB based drawing context using pango and cairo
-    #[derive(Clone, Debug)]
-    pub struct XcbDrawContext {
-        ctx: cairo::Context,
-        font: Option<pango::FontDescription>,
-        fonts: HashMap<String, pango::FontDescription>,
+    fn flush(&self, id: WinId) {
+        if let Some(s) = self.surfaces.get(&id) {
+            s.flush()
+        };
+        self.map_window(id);
+        self.api.flush();
     }
 
-    impl DrawContext for XcbDrawContext {
-        fn font(&mut self, font_name: &str, point_size: i32) -> Result<()> {
-            let mut font = self
-                .fonts
-                .get_mut(font_name)
-                .ok_or_else(|| DrawError::UnknownFont(font_name.into()))?
-                .clone();
-            font.set_size(point_size * pango::SCALE);
-            self.font = Some(font);
+    fn map_window(&self, id: WinId) {
+        self.api.map_window(id);
+    }
 
-            Ok(())
+    fn unmap_window(&self, id: WinId) {
+        self.api.unmap_window(id);
+    }
+
+    fn destroy_window(&self, id: WinId) {
+        self.api.destroy_window(id);
+    }
+
+    fn replace_prop(&self, id: WinId, prop: Atom, val: PropVal<'_>) {
+        self.api.replace_prop(id, prop, val);
+    }
+}
+
+/// An XCB based drawing context using pango and cairo
+#[derive(Clone, Debug)]
+pub struct XcbDrawContext {
+    ctx: cairo::Context,
+    font: Option<pango::FontDescription>,
+    fonts: HashMap<String, pango::FontDescription>,
+}
+
+impl DrawContext for XcbDrawContext {
+    fn font(&mut self, font_name: &str, point_size: i32) -> Result<()> {
+        let mut font = self
+            .fonts
+            .get_mut(font_name)
+            .ok_or_else(|| DrawError::UnknownFont(font_name.into()))?
+            .clone();
+        font.set_size(point_size * pango::SCALE);
+        self.font = Some(font);
+
+        Ok(())
+    }
+
+    fn color(&mut self, color: &Color) {
+        let (r, g, b, a) = color.rgba();
+        self.ctx.set_source_rgba(r, g, b, a);
+    }
+
+    fn clear(&mut self) {
+        self.ctx.save();
+        self.ctx.set_operator(cairo::Operator::Clear);
+        self.ctx.paint();
+        self.ctx.restore();
+    }
+
+    fn translate(&self, dx: f64, dy: f64) {
+        self.ctx.translate(dx, dy)
+    }
+
+    fn set_x_offset(&self, x: f64) {
+        let (_, y_offset) = self.ctx.get_matrix().transform_point(0.0, 0.0);
+        self.ctx.set_matrix(cairo::Matrix::identity());
+        self.ctx.translate(x, y_offset);
+    }
+
+    fn set_y_offset(&self, y: f64) {
+        let (x_offset, _) = self.ctx.get_matrix().transform_point(0.0, 0.0);
+        self.ctx.set_matrix(cairo::Matrix::identity());
+        self.ctx.translate(x_offset, y);
+    }
+
+    fn rectangle(&self, x: f64, y: f64, w: f64, h: f64) {
+        self.ctx.rectangle(x, y, w, h);
+        self.ctx.fill();
+    }
+
+    fn text(&self, txt: &str, h_offset: f64, padding: (f64, f64)) -> Result<(f64, f64)> {
+        let layout = pango_layout(&self.ctx)?;
+        if let Some(ref font) = self.font {
+            layout.set_font_description(Some(font));
         }
 
-        fn color(&mut self, color: &Color) {
-            let (r, g, b, a) = color.rgba();
-            self.ctx.set_source_rgba(r, g, b, a);
+        layout.set_text(txt);
+        layout.set_ellipsize(pango::EllipsizeMode::End);
+
+        let (w, h) = layout.get_pixel_size();
+        let (l, r) = padding;
+        self.ctx.translate(l, h_offset);
+        show_layout(&self.ctx, &layout);
+        self.ctx.translate(-l, -h_offset);
+
+        let width = w as f64 + l + r;
+        let height = h as f64;
+
+        Ok((width, height))
+    }
+
+    fn text_extent(&self, s: &str) -> Result<(f64, f64)> {
+        let layout = pango_layout(&self.ctx)?;
+        if let Some(ref font) = self.font {
+            layout.set_font_description(Some(font));
         }
+        layout.set_text(&s);
+        let (w, h) = layout.get_pixel_size();
 
-        fn clear(&mut self) {
-            self.ctx.save();
-            self.ctx.set_operator(cairo::Operator::Clear);
-            self.ctx.paint();
-            self.ctx.restore();
-        }
+        Ok((w as f64, h as f64))
+    }
 
-        fn translate(&self, dx: f64, dy: f64) {
-            self.ctx.translate(dx, dy)
-        }
-
-        fn set_x_offset(&self, x: f64) {
-            let (_, y_offset) = self.ctx.get_matrix().transform_point(0.0, 0.0);
-            self.ctx.set_matrix(cairo::Matrix::identity());
-            self.ctx.translate(x, y_offset);
-        }
-
-        fn set_y_offset(&self, y: f64) {
-            let (x_offset, _) = self.ctx.get_matrix().transform_point(0.0, 0.0);
-            self.ctx.set_matrix(cairo::Matrix::identity());
-            self.ctx.translate(x_offset, y);
-        }
-
-        fn rectangle(&self, x: f64, y: f64, w: f64, h: f64) {
-            self.ctx.rectangle(x, y, w, h);
-            self.ctx.fill();
-        }
-
-        fn text(&self, txt: &str, h_offset: f64, padding: (f64, f64)) -> Result<(f64, f64)> {
-            let layout = pango_layout(&self.ctx)?;
-            if let Some(ref font) = self.font {
-                layout.set_font_description(Some(font));
-            }
-
-            layout.set_text(txt);
-            layout.set_ellipsize(pango::EllipsizeMode::End);
-
-            let (w, h) = layout.get_pixel_size();
-            let (l, r) = padding;
-            self.ctx.translate(l, h_offset);
-            show_layout(&self.ctx, &layout);
-            self.ctx.translate(-l, -h_offset);
-
-            let width = w as f64 + l + r;
-            let height = h as f64;
-
-            Ok((width, height))
-        }
-
-        fn text_extent(&self, s: &str) -> Result<(f64, f64)> {
-            let layout = pango_layout(&self.ctx)?;
-            if let Some(ref font) = self.font {
-                layout.set_font_description(Some(font));
-            }
-            layout.set_text(&s);
-            let (w, h) = layout.get_pixel_size();
-
-            Ok((w as f64, h as f64))
-        }
-
-        fn flush(&self) {
-            self.ctx.get_target().flush();
-        }
+    fn flush(&self) {
+        self.ctx.get_target().flush();
     }
 }

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -3,7 +3,7 @@ use crate::core::{
     bindings::{KeyCode, MouseState},
     config::Config,
     data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
-    hooks::Hook,
+    hooks::{Hook, Hooks},
     manager::WindowManager,
     screen::Screen,
     xconnection::{Atom, XEvent},
@@ -76,6 +76,10 @@ pub enum XcbError {
 /// Result type for fallible methods using XCB
 pub type Result<T> = std::result::Result<T, XcbError>;
 
+/// Helper type for when you are defining your [Hook] vector in your main.rs when using
+/// the default XCB impls
+pub type XcbHooks = Hooks<XcbConnection<Api>>;
+
 /// Construct a default [XcbConnection] using the penrose provided [Api]
 /// implementation of [XcbApi].
 pub fn new_xcb_connection() -> crate::Result<XcbConnection<Api>> {
@@ -85,10 +89,10 @@ pub fn new_xcb_connection() -> crate::Result<XcbConnection<Api>> {
 /// Construct a penrose [WindowManager] backed by the default [xcb][crate::xcb] backend.
 pub fn new_xcb_backed_window_manager(
     config: Config,
-    hooks: Vec<Box<dyn Hook>>,
-) -> crate::Result<WindowManager> {
+    hooks: Vec<Box<dyn Hook<XcbConnection<Api>>>>,
+) -> crate::Result<WindowManager<XcbConnection<Api>>> {
     let conn = XcbConnection::new(Api::new()?)?;
-    let mut wm = WindowManager::new(config, Box::new(conn), hooks);
+    let mut wm = WindowManager::new(config, conn, hooks);
     wm.init();
 
     Ok(wm)

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -106,6 +106,10 @@ pub fn new_xcb_backed_window_manager(
  * the API nicer to work with in Penrose code.
  */
 pub trait XcbApi {
+    /// Hydrate this XcbApi to restore internal state following serde deserialization
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()>;
+
     /**
      * Intern an atom by name, returning the corresponding id.
      *

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -75,6 +75,11 @@ impl<X: XcbApi> XcbConnection<X> {
 }
 
 impl<X: XcbApi> XConn for XcbConnection<X> {
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()> {
+        Ok(self.api.hydrate()?)
+    }
+
     fn flush(&self) -> bool {
         self.api.flush()
     }

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -15,17 +15,18 @@ use crate::{
     core::{
         bindings::{KeyBindings, MouseBindings},
         data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
+        manager::WindowManager,
         screen::Screen,
         xconnection::{
             Atom, XConn, XEvent, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS,
             UNMANAGED_WINDOW_TYPES,
         },
     },
-    xcb::XcbApi,
+    xcb::{Api, XcbApi},
     Result,
 };
 
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 const WM_NAME: &str = "penrose";
 
@@ -71,6 +72,32 @@ impl<X: XcbApi> XcbConnection<X> {
             return win_types.contains(&atom);
         }
         false
+    }
+}
+
+impl XcbConnection<Api> {
+    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [API]
+    /// to communicate with the X server.
+    pub fn xcb_connectction(&self) -> &xcb::Connection {
+        &self.api.conn()
+    }
+
+    /// The current interned [Atom] values known to the underlying [Api] connection
+    pub fn known_atoms(&self) -> &HashMap<Atom, u32> {
+        &self.api.known_atoms()
+    }
+}
+
+impl WindowManager<XcbConnection<Api>> {
+    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [API]
+    /// to communicate with the X server.
+    pub fn xcb_connectction(&self) -> &xcb::Connection {
+        &self.conn().xcb_connectction()
+    }
+
+    /// The current interned [Atom] values known to the underlying [XcbConnection]
+    pub fn known_atoms(&self) -> &HashMap<Atom, u32> {
+        &self.conn().known_atoms()
     }
 }
 

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -76,7 +76,7 @@ impl<X: XcbApi> XcbConnection<X> {
 }
 
 impl XcbConnection<Api> {
-    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [API]
+    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [Api]
     /// to communicate with the X server.
     pub fn xcb_connectction(&self) -> &xcb::Connection {
         &self.api.conn()
@@ -89,7 +89,7 @@ impl XcbConnection<Api> {
 }
 
 impl WindowManager<XcbConnection<Api>> {
-    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [API]
+    /// Get a handle on the underlying [XCB Connection][::xcb::Connection] used by [Api]
     /// to communicate with the X server.
     pub fn xcb_connectction(&self) -> &xcb::Connection {
         &self.conn().xcb_connectction()

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -147,7 +147,7 @@ impl<X: XcbApi> XConn for XcbConnection<X> {
             .replace_prop(id, Atom::NetWmState, PropVal::Atom(&[data]));
     }
 
-    fn grab_keys(&self, key_bindings: &KeyBindings, mouse_bindings: &MouseBindings) {
+    fn grab_keys(&self, key_bindings: &KeyBindings<Self>, mouse_bindings: &MouseBindings<Self>) {
         self.api.grab_keys(&key_bindings.keys().collect::<Vec<_>>());
         self.api.grab_mouse_buttons(
             &mouse_bindings

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,6 +7,7 @@ use penrose::{
         ring::Selector,
         screen::Screen,
         workspace::Workspace,
+        xconnection::XConn,
     },
     Forward,
 };
@@ -40,41 +41,42 @@ fn layouts() -> Vec<Layout> {
     vec![Layout::new("t", LayoutConf::default(), side_stack, 1, 0.6)]
 }
 
-pub fn test_bindings() -> KeyBindings {
+pub fn test_bindings<X: XConn>() -> KeyBindings<X> {
     let mut bindings = HashMap::new();
     bindings.insert(
         EXIT_CODE,
-        Box::new(|wm: &mut WindowManager| wm.exit()) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.exit()) as FireAndForget<X>,
     );
     bindings.insert(
         LAYOUT_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.cycle_layout(Forward)) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_layout(Forward)) as FireAndForget<X>,
     );
     bindings.insert(
         WORKSPACE_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.focus_workspace(&Selector::Index(1))) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.focus_workspace(&Selector::Index(1)))
+            as FireAndForget<X>,
     );
     bindings.insert(
         ADD_WORKSPACE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.push_workspace(Workspace::new("new", layouts())))
-            as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.push_workspace(Workspace::new("new", layouts())))
+            as FireAndForget<X>,
     );
     bindings.insert(
         SCREEN_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.cycle_screen(Forward)) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_screen(Forward)) as FireAndForget<X>,
     );
     bindings.insert(
         FOCUS_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.cycle_client(Forward)) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_client(Forward)) as FireAndForget<X>,
     );
     bindings.insert(
         KILL_CLIENT_CODE,
-        Box::new(|wm: &mut WindowManager| wm.kill_client()) as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.kill_client()) as FireAndForget<X>,
     );
     bindings.insert(
         CLIENT_TO_WORKSPACE_CODE,
-        Box::new(|wm: &mut WindowManager| wm.client_to_workspace(&Selector::Index(1)))
-            as FireAndForget,
+        Box::new(|wm: &mut WindowManager<X>| wm.client_to_workspace(&Selector::Index(1)))
+            as FireAndForget<X>,
     );
 
     bindings

--- a/tests/hook_tests.rs
+++ b/tests/hook_tests.rs
@@ -5,7 +5,7 @@ use penrose::core::{
     data_types::WinId,
     hooks::{Hook, Hooks},
     manager::WindowManager,
-    xconnection::{MockXConn, XEvent},
+    xconnection::{MockXConn, XConn, XEvent},
 };
 
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
@@ -28,52 +28,52 @@ impl TestHook {
     }
 }
 
-impl Hook for TestHook {
-    fn new_client(&mut self, _: &mut WindowManager, _: &mut Client) {
+impl<X: XConn> Hook<X> for TestHook {
+    fn new_client(&mut self, _: &mut WindowManager<X>, _: &mut Client) {
         self.mark_called("new_client");
     }
 
-    fn remove_client(&mut self, _: &mut WindowManager, _: WinId) {
+    fn remove_client(&mut self, _: &mut WindowManager<X>, _: WinId) {
         self.mark_called("remove_client");
     }
 
-    fn client_name_updated(&mut self, _: &mut WindowManager, _: WinId, _: &str, _: bool) {
+    fn client_name_updated(&mut self, _: &mut WindowManager<X>, _: WinId, _: &str, _: bool) {
         self.mark_called("client_name_updated");
     }
 
-    fn client_added_to_workspace(&mut self, _: &mut WindowManager, _: WinId, _: usize) {
+    fn client_added_to_workspace(&mut self, _: &mut WindowManager<X>, _: WinId, _: usize) {
         self.mark_called("client_added_to_workspace");
     }
 
-    fn layout_applied(&mut self, _: &mut WindowManager, _: usize, _: usize) {
+    fn layout_applied(&mut self, _: &mut WindowManager<X>, _: usize, _: usize) {
         self.mark_called("layout_applied");
     }
 
-    fn layout_change(&mut self, _: &mut WindowManager, _: usize, _: usize) {
+    fn layout_change(&mut self, _: &mut WindowManager<X>, _: usize, _: usize) {
         self.mark_called("layout_change");
     }
 
-    fn workspace_change(&mut self, _: &mut WindowManager, _: usize, _: usize) {
+    fn workspace_change(&mut self, _: &mut WindowManager<X>, _: usize, _: usize) {
         self.mark_called("workspace_change");
     }
 
-    fn workspaces_updated(&mut self, _: &mut WindowManager, _: &[&str], _: usize) {
+    fn workspaces_updated(&mut self, _: &mut WindowManager<X>, _: &[&str], _: usize) {
         self.mark_called("workspaces_updated");
     }
 
-    fn screen_change(&mut self, _: &mut WindowManager, _: usize) {
+    fn screen_change(&mut self, _: &mut WindowManager<X>, _: usize) {
         self.mark_called("screen_change");
     }
 
-    fn focus_change(&mut self, _: &mut WindowManager, _: WinId) {
+    fn focus_change(&mut self, _: &mut WindowManager<X>, _: WinId) {
         self.mark_called("focus_change");
     }
 
-    fn startup(&mut self, _: &mut WindowManager) {
+    fn startup(&mut self, _: &mut WindowManager<X>) {
         self.mark_called("startup");
     }
 
-    fn event_handled(&mut self, _: &mut WindowManager) {
+    fn event_handled(&mut self, _: &mut WindowManager<X>) {
         self.mark_called("event_handled");
     }
 }
@@ -97,7 +97,7 @@ macro_rules! hook_test {
             };
 
             let config = Config::default();
-            let hooks: Hooks = vec![Box::new(hook_1), Box::new(hook_2)];
+            let hooks: Hooks<MockXConn> = vec![Box::new(hook_1), Box::new(hook_2)];
 
             let mut events = $evts.clone();
             events.push(XEvent::KeyPress(common::EXIT_CODE));
@@ -107,7 +107,7 @@ macro_rules! hook_test {
                 events,
                 vec![],
             );
-            let mut wm = WindowManager::new(config, Box::new(conn), hooks);
+            let mut wm = WindowManager::new(config, conn, hooks);
             wm.init();
             wm.grab_keys_and_run(common::test_bindings(), HashMap::new());
             drop(wm);

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 extern crate penrose;
 
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 


### PR DESCRIPTION
This makes `WindowManager` generic over the provided `XConn`. It is, understandibly, a _giant_ change for the API, in particular it makes `Hooks` and `Widgets` a bit more fidldy to work with which is annoying...

This is just a first pass that now compiles and passes the test suite, but ideally the API around `Hooks` (and therefor `Widgets`) can be tidied up. There is a problem with being able to make `Hook` impls into trait objects when they have generic parameters on methods so the API tidy-up might be a non-starter :disappointed: . If that's the case, I'll need to think about whether or not this change is worthwhile.

As a side effect of this, the recent `serde` support is slightly modified: `XConn` impls need to be (de-)serializable and support a new `hydrate` method if compiled with the `serde` feature enabled. This is to allow for restoring state and reconnecting to the X server which otherwise wouldn't work unless we continued injecting a new XConn which feels redundant at this point now.