### PR TITLE
Initial work on allowing Results in all user code

### DIFF
--- a/crates/penrose_menu/src/lib.rs
+++ b/crates/penrose_menu/src/lib.rs
@@ -20,8 +20,8 @@ use penrose::{
     },
     draw::{
         widget::{InputBox, LinesWithSelection, Text},
-        Color, DrawContext, DrawError, KeyPressDraw, KeyPressResult, KeyboardControlled, Result,
-        TextStyle, Widget,
+        Color, DrawContext, DrawError, KeyPressDraw, KeyPressParseAttempt, KeyboardControlled,
+        Result, TextStyle, Widget,
     },
 };
 
@@ -296,7 +296,7 @@ where
 
         loop {
             debug!("waiting for keypress");
-            if let KeyPressResult::KeyPress(k) = self.drw.next_keypress() {
+            if let Some(KeyPressParseAttempt::KeyPress(k)) = self.drw.next_keypress()? {
                 debug!("got a keypress");
                 match k {
                     KeyPress::Return if self.txt.selected_index() < matches.len() => {

--- a/crates/penrose_menu/src/lib.rs
+++ b/crates/penrose_menu/src/lib.rs
@@ -258,7 +258,7 @@ where
     /// # fn example<T: KeyPressDraw>(mut pmenu: PMenu<T>) -> Result<()> {
     /// let lines = vec!["foo", "bar", "baz"];
     ///
-    /// match pmenu.get_selection_from_input(">>> ", lines, 10, 0, 0.8, 0.8)? {
+    /// match pmenu.get_selection_from_input(">>> ", lines, 0)? {
     ///     PMenuMatch::Line(i, s) => println!("matched {} on line {}", s, i),
     ///     PMenuMatch::UserInput(s) => println!("user input: {}", s),
     ///     PMenuMatch::NoMatch => println!("no match"),

--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -8,6 +8,7 @@ use penrose::{
         xconnection::Atom,
     },
     draw::{bar::dwm_bar, Draw, DrawContext, TextStyle},
+    logging_error_handler,
     xcb::{new_xcb_backed_window_manager, XcbDraw},
     Result,
 };
@@ -51,13 +52,13 @@ fn bar_draw() -> Result<()> {
         workspaces,
     )?;
 
-    let mut wm = new_xcb_backed_window_manager(Config::default(), vec![])?;
-    bar.startup(&mut wm); // ensure widgets are initialised correctly
+    let mut wm = new_xcb_backed_window_manager(Config::default(), vec![], logging_error_handler())?;
+    bar.startup(&mut wm)?; // ensure widgets are initialised correctly
 
     thread::sleep(time::Duration::from_millis(1000));
     for focused in 1..6 {
-        bar.workspace_change(&mut wm, focused - 1, focused);
-        bar.event_handled(&mut wm);
+        bar.workspace_change(&mut wm, focused - 1, focused)?;
+        bar.event_handled(&mut wm)?;
         thread::sleep(time::Duration::from_millis(1000));
     }
 

--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -52,7 +52,8 @@ fn bar_draw() -> Result<()> {
         workspaces,
     )?;
 
-    let mut wm = new_xcb_backed_window_manager(Config::default(), vec![], logging_error_handler())?;
+    let mut wm =
+        new_xcb_backed_window_manager(Config::default(), vec![], logging_error_handler(), true)?;
     bar.startup(&mut wm)?; // ensure widgets are initialised correctly
 
     thread::sleep(time::Duration::from_millis(1000));

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
         };
     };
 
-    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler(), true)?;
     wm.grab_keys_and_run(key_bindings, HashMap::new())?;
 
     Ok(())

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -14,6 +14,7 @@ use penrose::{
         hooks::Hooks,
         layout::{bottom_stack, side_stack, Layout, LayoutConf},
     },
+    logging_error_handler,
     xcb::new_xcb_backed_window_manager,
     Backward, Forward, Less, More, Result,
 };
@@ -109,8 +110,8 @@ fn main() -> Result<()> {
         };
     };
 
-    let mut wm = new_xcb_backed_window_manager(config, hooks)?;
-    wm.grab_keys_and_run(key_bindings, HashMap::new());
+    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+    wm.grab_keys_and_run(key_bindings, HashMap::new())?;
 
     Ok(())
 }

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -11,6 +11,7 @@ use penrose::{
     core::{
         bindings::MouseEvent, config::Config, helpers::index_selectors, manager::WindowManager,
     },
+    logging_error_handler,
     xcb::new_xcb_backed_window_manager,
     Backward, Forward, Less, More, Result,
 };
@@ -51,8 +52,8 @@ fn main() -> Result<()> {
         Press Left + [Meta] => |wm: &mut WindowManager<_>, _: &MouseEvent| wm.cycle_workspace(Backward)
     };
 
-    let mut wm = new_xcb_backed_window_manager(config, hooks)?;
-    wm.grab_keys_and_run(key_bindings, mouse_bindings);
+    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+    wm.grab_keys_and_run(key_bindings, mouse_bindings)?;
 
     Ok(())
 }

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
         Press Left + [Meta] => |wm: &mut WindowManager<_>, _: &MouseEvent| wm.cycle_workspace(Backward)
     };
 
-    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler(), true)?;
     wm.grab_keys_and_run(key_bindings, mouse_bindings)?;
 
     Ok(())

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -180,7 +180,7 @@ fn main() -> Result<()> {
     // server. You are free to provide your own implementation if you wish, see xconnection.rs for
     // details of the required methods and expected behaviour and xcb/xconn.rs for the
     // implementation of XcbConnection.
-    let conn = XcbConnection::new()?;
+    let conn = XcbConnection::new(true)?;
 
     // Create the WindowManager instance with the config we have built and a connection to the X
     // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -25,6 +25,7 @@ use penrose::{
         ring::Selector,
         xconnection::XConn,
     },
+    logging_error_handler,
     xcb::{XcbConnection, XcbHooks},
     Backward, Forward, Less, More, Result,
 };
@@ -36,8 +37,8 @@ use std::collections::HashMap;
 // be run each time a new client program is spawned.
 struct MyClientHook {}
 impl<X: XConn> Hook<X> for MyClientHook {
-    fn new_client(&mut self, wm: &mut WindowManager<X>, c: &mut Client) {
-        wm.log(&format!("new client with WM_CLASS='{}'", c.wm_class()));
+    fn new_client(&mut self, wm: &mut WindowManager<X>, c: &mut Client) -> Result<()> {
+        wm.log(&format!("new client with WM_CLASS='{}'", c.wm_class()))
     }
 }
 
@@ -185,8 +186,8 @@ fn main() -> Result<()> {
     // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions
     // such as configuring initial WindowManager state, running custom code / hooks or spawning
     // external processes such as a start-up script.
-    let mut wm = WindowManager::new(config, conn, hooks);
-    wm.init();
+    let mut wm = WindowManager::new(config, conn, hooks, logging_error_handler());
+    wm.init()?;
 
     // NOTE: If you are using the default XCB backend provided in the penrose xcb module, then the
     //       construction of the XcbConnection and resulting WindowManager can be done using the
@@ -197,7 +198,7 @@ fn main() -> Result<()> {
     // grab_keys_and_run will start listening to events from the X server and drop into the main
     // event loop. From this point on, program control passes to the WindowManager so make sure
     // that any logic you wish to run is done before here!
-    wm.grab_keys_and_run(key_bindings, HashMap::new());
+    wm.grab_keys_and_run(key_bindings, HashMap::new())?;
 
     Ok(())
 }

--- a/src/core/bindings.rs
+++ b/src/core/bindings.rs
@@ -12,13 +12,13 @@ use std::{collections::HashMap, convert::TryFrom};
 use strum::EnumIter;
 
 /// Some action to be run by a user key binding
-pub type FireAndForget<X> = Box<dyn FnMut(&mut WindowManager<X>)>;
+pub type KeyEventHandler<X> = Box<dyn FnMut(&mut WindowManager<X>) -> Result<()>>;
 
 /// An action to be run in response to a mouse event
-pub type MouseEventHandler<X> = Box<dyn FnMut(&mut WindowManager<X>, &MouseEvent)>;
+pub type MouseEventHandler<X> = Box<dyn FnMut(&mut WindowManager<X>, &MouseEvent) -> Result<()>>;
 
 /// User defined key bindings
-pub type KeyBindings<X> = HashMap<KeyCode, FireAndForget<X>>;
+pub type KeyBindings<X> = HashMap<KeyCode, KeyEventHandler<X>>;
 
 /// User defined mouse bindings
 pub type MouseBindings<X> = HashMap<(MouseEventKind, MouseState), MouseEventHandler<X>>;

--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -116,7 +116,7 @@ pub fn logging_error_handler() -> ErrorHandler {
 /// message.
 pub fn notify_send_error_handler() -> ErrorHandler {
     Box::new(|e: PenroseError| {
-        if let Err(_) = spawn(format!("notify-send '{}'", e)) {
+        if spawn(format!("notify-send '{}'", e)).is_err() {
             error!("Unable to display error via notify-send. Error was: {}", e);
         }
     })

--- a/src/core/hooks.rs
+++ b/src/core/hooks.rs
@@ -1,9 +1,12 @@
 //! Hook for adding additional functionality around standard WindowManager actions
-use crate::core::{
-    client::Client,
-    data_types::{Region, WinId},
-    manager::WindowManager,
-    xconnection::XConn,
+use crate::{
+    core::{
+        client::Client,
+        data_types::{Region, WinId},
+        manager::WindowManager,
+        xconnection::XConn,
+    },
+    Result,
 };
 
 /// Utility type for defining hooks in your penrose configuration.
@@ -30,13 +33,17 @@ pub trait Hook<X: XConn> {
      * not passed back to penrose. If the hook takes ownership of the client, it is responsible
      * ensuring that it is unmapped.
      */
-    fn new_client(&mut self, _wm: &mut WindowManager<X>, _c: &mut Client) {}
+    fn new_client(&mut self, _wm: &mut WindowManager<X>, _c: &mut Client) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called when a Client is removed from the WindowManager, either through a user initiated
      * kill_client action or the Client exiting itself.
      */
-    fn remove_client(&mut self, _wm: &mut WindowManager<X>, _id: WinId) {}
+    fn remove_client(&mut self, _wm: &mut WindowManager<X>, _id: WinId) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called whenever something updates the WM_NAME or _NET_WM_NAME property on a window.
@@ -48,13 +55,21 @@ pub trait Hook<X: XConn> {
         _id: WinId,
         _name: &str,
         _is_root: bool,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 
     /**
      * Called whenever an existing [Client] is added to a [Workspace][crate::core::workspace::Workspace]
      */
-    fn client_added_to_workspace(&mut self, _wm: &mut WindowManager<X>, _id: WinId, _wix: usize) {}
+    fn client_added_to_workspace(
+        &mut self,
+        _wm: &mut WindowManager<X>,
+        _id: WinId,
+        _wix: usize,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called after a Layout is applied to the active Workspace.
@@ -67,7 +82,8 @@ pub trait Hook<X: XConn> {
         _wm: &mut WindowManager<X>,
         _workspace_index: usize,
         _screen_index: usize,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 
     /**
@@ -81,7 +97,8 @@ pub trait Hook<X: XConn> {
         _wm: &mut WindowManager<X>,
         _workspace_index: usize,
         _screen_index: usize,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 
     /**
@@ -94,20 +111,30 @@ pub trait Hook<X: XConn> {
         _wm: &mut WindowManager<X>,
         _previous_workspace: usize,
         _new_workspace: usize,
-    ) {
+    ) -> Result<()> {
+        Ok(())
     }
 
     /**
      * Called when there has been a change to the WindowManager workspace list.
      */
-    fn workspaces_updated(&mut self, _wm: &mut WindowManager<X>, _names: &[&str], _active: usize) {}
+    fn workspaces_updated(
+        &mut self,
+        _wm: &mut WindowManager<X>,
+        _names: &[&str],
+        _active: usize,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called after focus moves to a new Screen.
      * Argument is a index into the WindowManager screen array (internal data structure that supports
      * indexing) for the new Screen.
      */
-    fn screen_change(&mut self, _wm: &mut WindowManager<X>, _screen_index: usize) {}
+    fn screen_change(&mut self, _wm: &mut WindowManager<X>, _screen_index: usize) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called when the underlying [XConn] emitted a [RandrNotify][crate::core::xconnection::XEvent::RandrNotify]
@@ -116,19 +143,29 @@ pub trait Hook<X: XConn> {
      * This hook will run _before_ polling state for newly connected screens and running the
      * [screens_updated][Hook::screens_updated] hook.
      */
-    fn randr_notify(&mut self, _wm: &mut WindowManager<X>) {}
+    fn randr_notify(&mut self, _wm: &mut WindowManager<X>) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called when there has been a change to the WindowManager workspace list.
      */
-    fn screens_updated(&mut self, _wm: &mut WindowManager<X>, _dimensions: &[Region]) {}
+    fn screens_updated(
+        &mut self,
+        _wm: &mut WindowManager<X>,
+        _dimensions: &[Region],
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called after a new Client gains focus.
      * Argument is the focused Client ID which can be used to fetch the internal Client state if
      * needed.
      */
-    fn focus_change(&mut self, _wm: &mut WindowManager<X>, _id: WinId) {}
+    fn focus_change(&mut self, _wm: &mut WindowManager<X>, _id: WinId) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called at the end of the main WindowManager event loop once each XEvent has been handled.
@@ -136,10 +173,14 @@ pub trait Hook<X: XConn> {
      * Usefull if you want to ensure that all other event processing has taken place before you
      * take action in response to another hook.
      */
-    fn event_handled(&mut self, _wm: &mut WindowManager<X>) {}
+    fn event_handled(&mut self, _wm: &mut WindowManager<X>) -> Result<()> {
+        Ok(())
+    }
 
     /**
      * Called once at window manager startup
      */
-    fn startup(&mut self, _wm: &mut WindowManager<X>) {}
+    fn startup(&mut self, _wm: &mut WindowManager<X>) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -7,8 +7,8 @@
 macro_rules! run_external {
     ($cmd:tt) => {{
         Box::new(move |_: &mut $crate::core::manager::WindowManager<_>| {
-            $crate::core::helpers::spawn($cmd);
-        }) as $crate::core::bindings::FireAndForget<_>
+            $crate::core::helpers::spawn($cmd)
+        }) as $crate::core::bindings::KeyEventHandler<_>
     }};
 }
 
@@ -17,14 +17,14 @@ macro_rules! run_external {
 macro_rules! run_internal {
     ($func:ident) => {
         Box::new(|wm: &mut $crate::core::manager::WindowManager<_>| {
-            wm.$func();
-        }) as $crate::core::bindings::FireAndForget<_>
+            wm.$func()
+        }) as $crate::core::bindings::KeyEventHandler<_>
     };
 
     ($func:ident, $($arg:expr),+) => {
         Box::new(move |wm: &mut $crate::core::manager::WindowManager<_>| {
-            wm.$func($($arg),+);
-        }) as $crate::core::bindings::FireAndForget<_>
+            wm.$func($($arg),+)
+        }) as $crate::core::bindings::KeyEventHandler<_>
     };
 }
 
@@ -160,6 +160,8 @@ macro_rules! str_slice {
 // NOTE: requires that you provide a `validate` method on the builder and
 //       some way of getting an initial value of the real struct (i.e. impl
 //       Default)
+#[doc(hidden)]
+#[macro_export]
 macro_rules! __with_builder_and_getters {
     {
         $(#[$struct_outer:meta])*
@@ -242,9 +244,9 @@ macro_rules! __with_builder_and_getters {
     }
 }
 
+/// Helper for writing paramaterised test cases
 #[doc(hidden)]
 #[macro_export]
-/// Helper for writing paramaterised test cases
 macro_rules! test_cases {
     {
         $test_name:ident;

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -11,11 +11,11 @@ use crate::{
         workspace::Workspace,
         xconnection::{Atom, XConn},
     },
-    Result,
+    ErrorHandler, PenroseError, Result,
 };
 
 #[cfg(feature = "serde")]
-use crate::core::layout::LayoutFunc;
+use crate::core::{helpers::logging_error_handler, layout::LayoutFunc};
 
 use nix::sys::signal::{signal, SigHandler, Signal};
 
@@ -34,8 +34,11 @@ macro_rules! run_hooks {
     ($method:ident, $_self:expr, $($arg:expr),*) => {
         debug!("Running {} hooks", stringify!($method));
         let mut hooks = $_self.hooks.replace(vec![]);
-        hooks.iter_mut().for_each(|h| h.$method($_self, $($arg),*));
+        let res = hooks.iter_mut().try_for_each(|h| h.$method($_self, $($arg),*));
         $_self.hooks.replace(hooks);
+        if let Err(e) = res {
+            ($_self.error_handler)(e);
+        }
     };
 }
 
@@ -70,6 +73,8 @@ pub struct WindowManager<X: XConn> {
     client_insert_point: InsertPoint,
     focused_client: Option<WinId>,
     running: bool,
+    #[cfg_attr(feature = "serde", serde(skip, default = "logging_error_handler"))]
+    error_handler: ErrorHandler,
     #[cfg_attr(feature = "serde", serde(skip))]
     hydrated: bool,
 }
@@ -98,21 +103,28 @@ impl<X: XConn> WindowManager<X> {
      *
      * # Example
      * ```no_run
-     * use penrose::{core::{Config, WindowManager}, xcb::XcbConnection};
+     * use penrose::{
+     *     core::{Config, WindowManager},
+     *     xcb::XcbConnection,
+     *     logging_error_handler
+     * };
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
      *     XcbConnection::new().unwrap(),
-     *     vec![]
+     *     vec![],
+     *     logging_error_handler()
      * );
      *
      * // additional set-up logic here
      *
-     * wm.init();
-     * wm.log("ready to call grab_keys_and_run!");
+     * if let Err(e) = wm.init() {
+     *     panic!("failed to initialise WindowManager: {}", e);
+     * }
+     * wm.log("ready to call grab_keys_and_run!").unwrap();
      * ```
      */
-    pub fn new(config: Config, conn: X, hooks: Hooks<X>) -> Self {
+    pub fn new(config: Config, conn: X, hooks: Hooks<X>, error_handler: ErrorHandler) -> Self {
         let layouts = config.layouts.clone();
 
         debug!("Building initial workspaces");
@@ -134,6 +146,7 @@ impl<X: XConn> WindowManager<X> {
             focused_client: None,
             running: false,
             hydrated: true,
+            error_handler,
         }
     }
 
@@ -159,6 +172,7 @@ impl<X: XConn> WindowManager<X> {
     ///         manager::WindowManager,
     ///     },
     ///     xcb::XcbConnection,
+    ///     logging_error_handler
     /// };
     ///
     /// # fn example() -> Result<()> {
@@ -178,7 +192,7 @@ impl<X: XConn> WindowManager<X> {
     ///
     /// let json_str = "...";  // Load in the serialized state from somewhere
     /// let mut manager: WindowManager<XcbConnection> = serde_json::from_str(&json_str).unwrap();
-    /// assert!(manager.hydrate_and_init(hooks, layout_funcs).is_ok());
+    /// assert!(manager.hydrate_and_init(hooks, logging_error_handler(), layout_funcs).is_ok());
     /// # Ok(())
     /// # }
     /// ```
@@ -186,17 +200,19 @@ impl<X: XConn> WindowManager<X> {
     pub fn hydrate_and_init(
         &mut self,
         hooks: Hooks<X>,
+        error_handler: ErrorHandler,
         layout_funcs: HashMap<&str, LayoutFunc>,
     ) -> Result<()> {
         self.conn.hydrate()?;
         self.hooks.set(hooks);
+        self.error_handler = error_handler;
         self.workspaces
             .iter_mut()
             .try_for_each(|w| w.restore_layout_functions(&layout_funcs))?;
 
         util::validate_hydrated_wm_state(self)?;
         self.hydrated = true;
-        self.init();
+        self.init()?;
         Ok(())
     }
 
@@ -208,27 +224,34 @@ impl<X: XConn> WindowManager<X> {
      *
      * # Example
      * ```no_run
-     * use penrose::{core::{Config, WindowManager}, xcb::XcbConnection};
+     * use penrose::{
+     *     core::{Config, WindowManager},
+     *     xcb::XcbConnection,
+     *     logging_error_handler
+     * };
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
      *     XcbConnection::new().unwrap(),
-     *     vec![]
+     *     vec![],
+     *     logging_error_handler()
      * );
      *
      * // additional set-up logic here
      *
-     * wm.init();
-     * wm.log("ready to call grab_keys_and_run!");
+     * if let Err(e) = wm.init() {
+     *     panic!("failed to initialise WindowManager: {}", e);
+     * }
+     * wm.log("ready to call grab_keys_and_run!").unwrap();
      * ```
      */
-    pub fn init(&mut self) {
+    pub fn init(&mut self) -> Result<()> {
         if !self.hydrated {
             panic!("Need to call 'hydrate_and_init' when restoring from serialised state")
         }
 
         debug!("Attempting initial screen detection");
-        self.detect_screens();
+        self.detect_screens()?;
 
         debug!("Setting EWMH properties");
         self.conn
@@ -236,6 +259,8 @@ impl<X: XConn> WindowManager<X> {
 
         debug!("Forcing cursor to first screen");
         self.conn.warp_cursor(None, &self.screens[0]);
+
+        Ok(())
     }
 
     // Subset of current immutable state that is needed for processing XEvents into EventActions
@@ -266,7 +291,7 @@ impl<X: XConn> WindowManager<X> {
             EventAction::DestroyClient(id) => self.remove_client(id),
             EventAction::DetectScreens => {
                 run_hooks!(randr_notify, self,);
-                self.detect_screens()
+                self.detect_screens()?
             }
             EventAction::MapWindow(id) => self.handle_map_request(id)?,
             EventAction::RunKeyBinding(k) => self.run_key_binding(k, key_bindings),
@@ -295,7 +320,7 @@ impl<X: XConn> WindowManager<X> {
         &mut self,
         mut key_bindings: KeyBindings<X>,
         mut mouse_bindings: MouseBindings<X>,
-    ) {
+    ) -> Result<()> {
         if self.running {
             panic!("Attempt to call grab_keys_and_run while already running");
         }
@@ -312,7 +337,7 @@ impl<X: XConn> WindowManager<X> {
         debug!("Grabbing key and mouse bindings");
         self.conn.grab_keys(&key_bindings, &mouse_bindings);
         debug!("Forcing focus to first Workspace");
-        self.focus_workspace(&Selector::Index(0));
+        self.focus_workspace(&Selector::Index(0))?;
         run_hooks!(startup, self,);
         self.running = true;
 
@@ -324,13 +349,15 @@ impl<X: XConn> WindowManager<X> {
                     if let Err(e) =
                         self.handle_event_action(action, &mut key_bindings, &mut mouse_bindings)
                     {
-                        warn!("Error handling event: {}", e);
+                        (self.error_handler)(e);
                     }
                 }
                 run_hooks!(event_handled, self,);
             }
             self.conn.flush();
         }
+
+        Ok(())
     }
 
     /*
@@ -455,7 +482,7 @@ impl<X: XConn> WindowManager<X> {
 
     /// Query the [XConn] for the current connected [Screen] list and reposition displayed
     /// [Workspace] instances if needed.
-    pub fn detect_screens(&mut self) {
+    pub fn detect_screens(&mut self) -> Result<()> {
         let screens = util::get_screens(
             &self.conn,
             self.visible_workspaces(),
@@ -465,7 +492,7 @@ impl<X: XConn> WindowManager<X> {
         );
 
         if screens == self.screens.as_vec() {
-            return; // nothing changed
+            return Ok(()); // nothing changed
         }
 
         info!("Updating known screens: {} screens detected", screens.len());
@@ -476,6 +503,8 @@ impl<X: XConn> WindowManager<X> {
 
         let regions = self.screens.vec_map(|s| s.region(false));
         run_hooks!(screens_updated, self, &regions);
+
+        Ok(())
     }
 
     // Map a new client window.
@@ -542,7 +571,10 @@ impl<X: XConn> WindowManager<X> {
     fn run_key_binding(&mut self, k: KeyCode, bindings: &mut KeyBindings<X>) {
         debug!("handling key code: {:?}", k);
         if let Some(action) = bindings.get_mut(&k) {
-            action(self); // ignoring Child handlers and SIGCHILD
+            // ignoring Child handlers and SIGCHILD
+            if let Err(e) = action(self) {
+                (self.error_handler)(e);
+            }
         }
     }
 
@@ -552,7 +584,10 @@ impl<X: XConn> WindowManager<X> {
     fn run_mouse_binding(&mut self, e: MouseEvent, bindings: &mut MouseBindings<X>) {
         debug!("handling mouse event: {:?} {:?}", e.state, e.kind);
         if let Some(action) = bindings.get_mut(&(e.kind, e.state.clone())) {
-            action(self, &e); // ignoring Child handlers and SIGCHILD
+            // ignoring Child handlers and SIGCHILD
+            if let Err(e) = action(self, &e) {
+                (self.error_handler)(e);
+            }
         }
     }
 
@@ -674,19 +709,26 @@ impl<X: XConn> WindowManager<X> {
      *
      * # Example
      * ```no_run
-     * use penrose::{core::{Config, WindowManager}, xcb::XcbConnection};
+     * use penrose::{
+     *     core::{Config, WindowManager},
+     *     xcb::XcbConnection,
+     *     logging_error_handler
+     * };
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
      *     XcbConnection::new().unwrap(),
-     *     vec![]
+     *     vec![],
+     *     logging_error_handler()
      * );
      *
-     * wm.log("hello from penrose");
+     * wm.log("hello from penrose").unwrap();
      * ```
      */
-    pub fn log(&self, msg: &str) {
+    pub fn log(&self, msg: &str) -> Result<()> {
         info!("{}", msg);
+
+        Ok(())
     }
 
     /**
@@ -694,22 +736,29 @@ impl<X: XConn> WindowManager<X> {
      *
      * # Example
      * ```no_run
-     * use penrose::{core::{Config, WindowManager}, xcb::XcbConnection, Forward};
+     * use penrose::{
+     *     core::{Config, WindowManager},
+     *     xcb::XcbConnection,
+     *     Forward, logging_error_handler
+     * };
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
      *     XcbConnection::new().unwrap(),
-     *     vec![]
+     *     vec![],
+     *     logging_error_handler()
      * );
      *
-     * wm.init();
+     * if let Err(e) = wm.init() {
+     *     panic!("failed to initialise WindowManager: {}", e);
+     * }
      *
      * assert_eq!(wm.active_screen_index(), 0);
-     * wm.cycle_screen(Forward);
+     * wm.cycle_screen(Forward).unwrap();
      * assert_eq!(wm.active_screen_index(), 1);
      * ```
      */
-    pub fn cycle_screen(&mut self, direction: Direction) {
+    pub fn cycle_screen(&mut self, direction: Direction) -> Result<()> {
         if !self.screens.would_wrap(direction) {
             self.screens.cycle_focus(direction);
             let i = self.screens.focused_unchecked().wix;
@@ -722,27 +771,29 @@ impl<X: XConn> WindowManager<X> {
             let i = self.screens.focused_index();
             run_hooks!(screen_change, self, i);
         }
+
+        Ok(())
     }
 
     /**
      * Cycle between [workspaces][Workspace] on the current [screen][Screen]. This will pull
      * workspaces to the screen if they are currently displayed on another screen.
      */
-    pub fn cycle_workspace(&mut self, direction: Direction) {
+    pub fn cycle_workspace(&mut self, direction: Direction) -> Result<()> {
         self.workspaces.cycle_focus(direction);
         let i = self.workspaces.focused_index();
-        self.focus_workspace(&Selector::Index(i));
+        self.focus_workspace(&Selector::Index(i))
     }
 
     /// Move the currently focused [workspace][Workspace] to the next [screen][Screen] in 'direction'
-    pub fn drag_workspace(&mut self, direction: Direction) {
+    pub fn drag_workspace(&mut self, direction: Direction) -> Result<()> {
         let wix = self.active_ws_index();
-        self.cycle_screen(direction);
-        self.focus_workspace(&Selector::Index(wix)); // focus_workspace will pull it to the new screen
+        self.cycle_screen(direction)?;
+        self.focus_workspace(&Selector::Index(wix)) // focus_workspace will pull it to the new screen
     }
 
     /// Cycle between [clients][Client] for the active [workspace][Workspace]
-    pub fn cycle_client(&mut self, direction: Direction) {
+    pub fn cycle_client(&mut self, direction: Direction) -> Result<()> {
         let wix = self.active_ws_index();
         let res = self
             .workspaces
@@ -754,6 +805,8 @@ impl<X: XConn> WindowManager<X> {
             let screen = self.screens.focused_unchecked();
             self.conn.warp_cursor(Some(new), screen);
         }
+
+        Ok(())
     }
 
     /// Focus the [Client] matching the given [Selector]
@@ -777,16 +830,18 @@ impl<X: XConn> WindowManager<X> {
     }
 
     /// Rotate the [client][Client] stack on the active [workspace][Workspace]
-    pub fn rotate_clients(&mut self, direction: Direction) {
+    pub fn rotate_clients(&mut self, direction: Direction) -> Result<()> {
         let wix = self.active_ws_index();
         if let Some(ws) = self.workspaces.get_mut(wix) {
             ws.rotate_clients(direction)
         };
+
+        Ok(())
     }
 
     /// Move the focused [client][Client] through the stack of clients on the active
     /// [workspace][Workspace]
-    pub fn drag_client(&mut self, direction: Direction) {
+    pub fn drag_client(&mut self, direction: Direction) -> Result<()> {
         if let Some(id) = self.focused_client().map(|c| c.id()) {
             let wix = self.active_ws_index();
             self.workspaces
@@ -797,43 +852,53 @@ impl<X: XConn> WindowManager<X> {
             self.conn
                 .warp_cursor(Some(id), self.screens.focused_unchecked());
         }
+
+        Ok(())
     }
 
     /// Cycle between [layouts][crate::core::layout::Layout] for the active [workspace][Workspace]
-    pub fn cycle_layout(&mut self, direction: Direction) {
+    pub fn cycle_layout(&mut self, direction: Direction) -> Result<()> {
         let wix = self.active_ws_index();
         if let Some(ws) = self.workspaces.get_mut(wix) {
             ws.cycle_layout(direction);
         }
         run_hooks!(layout_change, self, wix, self.active_screen_index());
         self.apply_layout(wix);
+
+        Ok(())
     }
 
     /// Increase or decrease the number of clients in the main area by 1
-    pub fn update_max_main(&mut self, change: Change) {
+    pub fn update_max_main(&mut self, change: Change) -> Result<()> {
         let wix = self.active_ws_index();
         if let Some(ws) = self.workspaces.get_mut(wix) {
             ws.update_max_main(change)
         };
         self.apply_layout(wix);
+
+        Ok(())
     }
 
     /// Increase or decrease the current [layout][crate::core::layout::Layout] main_ratio by
     /// main_ratio_step
-    pub fn update_main_ratio(&mut self, change: Change) {
+    pub fn update_main_ratio(&mut self, change: Change) -> Result<()> {
         let step = self.config.main_ratio_step;
         let wix = self.active_ws_index();
         if let Some(ws) = self.workspaces.get_mut(wix) {
             ws.update_main_ratio(change, step)
         }
         self.apply_layout(wix);
+
+        Ok(())
     }
 
     /// Shut down the WindowManager, running any required cleanup and exiting penrose
-    pub fn exit(&mut self) {
+    pub fn exit(&mut self) -> Result<()> {
         self.conn.cleanup();
         self.conn.flush();
         self.running = false;
+
+        Ok(())
     }
 
     /// The layout symbol for the [layout][crate::core::layout::Layout] currently being used on the
@@ -846,13 +911,17 @@ impl<X: XConn> WindowManager<X> {
     }
 
     /// Set the root X window name. Useful for exposing information to external programs
-    pub fn set_root_window_name(&self, s: &str) {
+    pub fn set_root_window_name(&self, s: &str) -> Result<()> {
         self.conn.set_root_window_name(s);
+
+        Ok(())
     }
 
     /// Set the insert point for new clients. Default is to insert at index 0.
-    pub fn set_client_insert_point(&mut self, cip: InsertPoint) {
+    pub fn set_client_insert_point(&mut self, cip: InsertPoint) -> Result<()> {
         self.client_insert_point = cip;
+
+        Ok(())
     }
 
     /**
@@ -862,10 +931,10 @@ impl<X: XConn> WindowManager<X> {
      * invalid index. You should almost always be using the `gen_keybindings!` macro
      * to set up your keybindings so this is not normally an issue.
      */
-    pub fn focus_workspace(&mut self, selector: &Selector<'_, Workspace>) {
+    pub fn focus_workspace(&mut self, selector: &Selector<'_, Workspace>) -> Result<()> {
         let active_ws = Selector::Index(self.screens.focused_unchecked().wix);
         if self.workspaces.equivalent_selectors(selector, &active_ws) {
-            return;
+            return Ok(());
         }
 
         if let Some(index) = self.workspaces.index(selector) {
@@ -891,7 +960,7 @@ impl<X: XConn> WindowManager<X> {
 
                     self.workspaces.focus(&Selector::Index(index));
                     run_hooks!(workspace_change, self, active, index);
-                    return;
+                    return Ok(());
                 }
             }
 
@@ -921,18 +990,20 @@ impl<X: XConn> WindowManager<X> {
             self.workspaces.focus(&Selector::Index(index));
             run_hooks!(workspace_change, self, active, index);
         }
+
+        Ok(())
     }
 
     /// Switch focus back to the last workspace that had focus.
-    pub fn toggle_workspace(&mut self) {
-        self.focus_workspace(&Selector::Index(self.previous_workspace));
+    pub fn toggle_workspace(&mut self) -> Result<()> {
+        self.focus_workspace(&Selector::Index(self.previous_workspace))
     }
 
     /// Move the focused client to the workspace matching 'selector'.
-    pub fn client_to_workspace(&mut self, selector: &Selector<'_, Workspace>) {
+    pub fn client_to_workspace(&mut self, selector: &Selector<'_, Workspace>) -> Result<()> {
         let active_ws = Selector::Index(self.screens.focused_unchecked().wix);
         if self.workspaces.equivalent_selectors(&selector, &active_ws) {
-            return;
+            return Ok(());
         }
 
         if let Some(index) = self.workspaces.index(&selector) {
@@ -960,28 +1031,32 @@ impl<X: XConn> WindowManager<X> {
                 }
             };
         }
+
+        Ok(())
     }
 
     /// Move the focused client to the active workspace on the screen matching 'selector'.
-    pub fn client_to_screen(&mut self, selector: &Selector<'_, Screen>) {
+    pub fn client_to_screen(&mut self, selector: &Selector<'_, Screen>) -> Result<()> {
         let i = match self.screen(selector) {
             Some(s) => s.wix,
-            None => return,
+            None => return Ok(()),
         };
-        self.client_to_workspace(&Selector::Index(i));
+        self.client_to_workspace(&Selector::Index(i))
     }
 
     /// Toggle the fullscreen state of the given client ID
-    pub fn toggle_client_fullscreen(&mut self, selector: &Selector<'_, Client>) {
+    pub fn toggle_client_fullscreen(&mut self, selector: &Selector<'_, Client>) -> Result<()> {
         let (id, client_is_fullscreen) = match self.client(selector) {
-            None => return, // unknown client
+            None => return Ok(()), // unknown client
             Some(c) => (c.id(), c.fullscreen),
         };
         self.set_fullscreen(id, !client_is_fullscreen);
+
+        Ok(())
     }
 
     /// Kill the focused client window.
-    pub fn kill_client(&mut self) {
+    pub fn kill_client(&mut self) -> Result<()> {
         let id = self.conn.focused_client();
         let del = Atom::WmDeleteWindow.as_ref();
         if let Err(e) = self.conn.send_client_event(id, del) {
@@ -991,6 +1066,8 @@ impl<X: XConn> WindowManager<X> {
 
         self.remove_client(id);
         self.apply_layout(self.active_ws_index());
+
+        Ok(())
     }
 
     /// Get a reference to the first Screen satisfying 'selector'. WinId selectors will return
@@ -1013,34 +1090,46 @@ impl<X: XConn> WindowManager<X> {
     }
 
     /// Add a new workspace at `index`, shifting all workspaces with indices greater to the right.
-    pub fn add_workspace(&mut self, index: usize, ws: Workspace) {
+    pub fn add_workspace(&mut self, index: usize, ws: Workspace) -> Result<()> {
         self.workspaces.insert(index, ws);
         self.update_x_workspace_details();
+
+        Ok(())
     }
 
     /// Add a new workspace at the end of the current workspace list
-    pub fn push_workspace(&mut self, ws: Workspace) {
+    pub fn push_workspace(&mut self, ws: Workspace) -> Result<()> {
         self.workspaces.push(ws);
         self.update_x_workspace_details();
+
+        Ok(())
     }
 
     /// Remove a Workspace from the WindowManager. All clients that were present on the removed
     /// workspace will be destroyed. WinId selectors will be ignored.
-    pub fn remove_workspace(&mut self, selector: &Selector<'_, Workspace>) -> Option<Workspace> {
+    pub fn remove_workspace(
+        &mut self,
+        selector: &Selector<'_, Workspace>,
+    ) -> Result<Option<Workspace>> {
         if self.workspaces.len() == 1 {
-            return None; // not allowed to remove the last workspace
+            return Err(PenroseError::Raw(
+                "not allowed to remove the last workspace".into(),
+            ));
         }
 
-        let ws = self.workspaces.remove(&selector)?;
+        let ws = self
+            .workspaces
+            .remove(&selector)
+            .ok_or_else(|| PenroseError::Raw("unknown workspace".into()))?;
         ws.iter().for_each(|c| self.remove_client(*c));
 
         // Focus the workspace before the one we just removed. There is always at least one
         // workspace before this one due to the guard above.
-        let ix = self.screens.focused()?.wix - 1;
-        self.focus_workspace(&Selector::Index(ix));
+        let ix = self.screens.focused_unchecked().wix - 1;
+        self.focus_workspace(&Selector::Index(ix))?;
 
         self.update_x_workspace_details();
-        Some(ws)
+        Ok(Some(ws))
     }
 
     /// Get a reference to the first Workspace satisfying 'selector'. WinId selectors will return
@@ -1107,11 +1196,13 @@ impl<X: XConn> WindowManager<X> {
         &mut self,
         name: impl Into<String>,
         selector: Selector<'_, Workspace>,
-    ) {
+    ) -> Result<()> {
         if let Some(ws) = self.workspaces.element_mut(&selector) {
             ws.set_name(name)
         };
         self.update_x_workspace_details();
+
+        Ok(())
     }
 
     /// Take a reference to the first Client found matching 'selector'
@@ -1215,27 +1306,32 @@ impl<X: XConn> WindowManager<X> {
 
     /// Position an individual client on the display. (x,y) coordinates are absolute (i.e. relative
     /// to the root window not any individual screen).
-    pub fn position_client(&self, id: WinId, region: Region, stack_above: bool) {
+    pub fn position_client(&self, id: WinId, region: Region, stack_above: bool) -> Result<()> {
         self.conn
             .position_window(id, region, self.config.border_px, stack_above);
+        Ok(())
     }
 
     /// Make the Client with ID 'id' visible at its last known position.
-    pub fn show_client(&mut self, id: WinId) {
+    pub fn show_client(&mut self, id: WinId) -> Result<()> {
         util::map_window_if_needed(&self.conn, self.client_map.get_mut(&id));
         self.conn.set_client_workspace(id, self.active_ws_index());
+        Ok(())
     }
 
     /// Hide the Client with ID 'id'.
-    pub fn hide_client(&mut self, id: WinId) {
+    pub fn hide_client(&mut self, id: WinId) -> Result<()> {
         util::unmap_window_if_needed(&self.conn, self.client_map.get_mut(&id));
+        Ok(())
     }
 
     /// Layout the workspace currently shown on the given screen index.
-    pub fn layout_screen(&mut self, screen_index: usize) {
+    pub fn layout_screen(&mut self, screen_index: usize) -> Result<()> {
         if let Some(wix) = self.screens.get(screen_index).map(|s| s.wix) {
             self.apply_layout(wix)
         }
+
+        Ok(())
     }
 
     /// An index into the WindowManager known screens for the screen that is currently focused
@@ -1260,8 +1356,8 @@ mod tests {
             layouts: test_layouts(),
             ..Default::default()
         };
-        let mut wm = WindowManager::new(conf, conn, vec![]);
-        wm.init();
+        let mut wm = WindowManager::new(conf, conn, vec![], logging_error_handler());
+        wm.init().unwrap();
 
         wm
     }
@@ -1293,13 +1389,13 @@ mod tests {
         assert_eq!(wm.workspaces[0].focused_client(), Some(30));
 
         // switch and add to the second workspace: final client should have focus
-        wm.focus_workspace(&Selector::Index(1));
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
         add_n_clients(&mut wm, 2, 3);
         assert_eq!(wm.workspaces[1].len(), 2);
         assert_eq!(wm.workspaces[1].focused_client(), Some(50));
 
         // switch back: clients should be the same, same client should have focus
-        wm.focus_workspace(&Selector::Index(0));
+        wm.focus_workspace(&Selector::Index(0)).unwrap();
         assert_eq!(wm.workspaces[0].len(), 3);
         assert_eq!(wm.workspaces[0].focused_client(), Some(30));
     }
@@ -1308,7 +1404,7 @@ mod tests {
     fn killing_a_client_removes_it_from_the_workspace() {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 1, 0);
-        wm.kill_client();
+        wm.kill_client().unwrap();
 
         assert_eq!(wm.workspaces[0].len(), 0);
     }
@@ -1318,9 +1414,9 @@ mod tests {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 5, 0); // 50 40 30 20 10, 50 focused
         assert_eq!(wm.active_ws_index(), 0);
-        wm.cycle_client(Forward); // 40 focused
+        wm.cycle_client(Forward).unwrap(); // 40 focused
         assert_eq!(wm.workspaces[0].focused_client(), Some(40));
-        wm.kill_client(); // remove 40, focus 30
+        wm.kill_client().unwrap(); // remove 40, focus 30
 
         let ids: Vec<WinId> = wm.workspaces[0].iter().cloned().collect();
         assert_eq!(ids, vec![50, 30, 20, 10]);
@@ -1331,10 +1427,10 @@ mod tests {
     fn moving_then_deleting_clients() {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 2, 0);
-        wm.client_to_workspace(&Selector::Index(1));
-        wm.client_to_workspace(&Selector::Index(1));
-        wm.focus_workspace(&Selector::Index(1));
-        wm.kill_client();
+        wm.client_to_workspace(&Selector::Index(1)).unwrap();
+        wm.client_to_workspace(&Selector::Index(1)).unwrap();
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
+        wm.kill_client().unwrap();
 
         // should have removed first client on ws::1 (last sent from ws::0)
         assert_eq!(wm.workspaces[1].iter().collect::<Vec<&WinId>>(), vec![&20]);
@@ -1344,9 +1440,9 @@ mod tests {
     fn client_to_workspace_inserts_at_head() {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 2, 0); // [20, 10]
-        wm.client_to_workspace(&Selector::Index(1)); // 20 -> ws::1
-        wm.client_to_workspace(&Selector::Index(1)); // 10 -> ws::1, [10, 20]
-        wm.focus_workspace(&Selector::Index(1));
+        wm.client_to_workspace(&Selector::Index(1)).unwrap(); // 20 -> ws::1
+        wm.client_to_workspace(&Selector::Index(1)).unwrap(); // 10 -> ws::1, [10, 20]
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
 
         assert_eq!(
             wm.workspaces[1].iter().collect::<Vec<&WinId>>(),
@@ -1358,9 +1454,9 @@ mod tests {
     fn client_to_workspace_sets_focus() {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 2, 0); // [20, 10]
-        wm.client_to_workspace(&Selector::Index(1)); // 20 -> ws::1
-        wm.client_to_workspace(&Selector::Index(1)); // 10 -> ws::1, [10, 20]
-        wm.focus_workspace(&Selector::Index(1));
+        wm.client_to_workspace(&Selector::Index(1)).unwrap(); // 20 -> ws::1
+        wm.client_to_workspace(&Selector::Index(1)).unwrap(); // 10 -> ws::1, [10, 20]
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
 
         assert_eq!(wm.workspaces[1].focused_client(), Some(10));
     }
@@ -1371,7 +1467,7 @@ mod tests {
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
         assert_eq!(wm.client_map.get(&10).map(|c| c.workspace()), Some(0));
-        wm.client_to_workspace(&Selector::Index(42));
+        wm.client_to_workspace(&Selector::Index(42)).unwrap();
         assert_eq!(wm.client_map.get(&10).map(|c| c.workspace()), Some(0));
     }
 
@@ -1380,7 +1476,7 @@ mod tests {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
-        wm.client_to_screen(&Selector::Index(1));
+        wm.client_to_screen(&Selector::Index(1)).unwrap();
         assert_eq!(wm.client_map.get(&10).map(|c| c.workspace()), Some(1));
     }
 
@@ -1390,7 +1486,7 @@ mod tests {
         add_n_clients(&mut wm, 1, 0); // [20, 10]
 
         assert_eq!(wm.client_map.get(&10).map(|c| c.workspace()), Some(0));
-        wm.client_to_screen(&Selector::Index(5));
+        wm.client_to_screen(&Selector::Index(5)).unwrap();
         assert_eq!(wm.client_map.get(&10).map(|c| c.workspace()), Some(0));
     }
 
@@ -1408,7 +1504,7 @@ mod tests {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
         assert_eq!(wm.workspaces.focused_index(), 0);
         assert_eq!(wm.workspaces.focused_index(), wm.active_ws_index());
-        wm.focus_workspace(&Selector::Index(3));
+        wm.focus_workspace(&Selector::Index(3)).unwrap();
         assert_eq!(wm.workspaces.focused_index(), 3);
         assert_eq!(wm.workspaces.focused_index(), wm.active_ws_index());
     }
@@ -1425,16 +1521,16 @@ mod tests {
                 .collect::<Vec<_>>()
         };
 
-        wm.drag_client(Forward);
+        wm.drag_client(Forward).unwrap();
         assert_eq!(wm.focused_client().unwrap().id(), 50);
         assert_eq!(clients(&mut wm), vec![40, 50, 30, 20, 10]);
 
-        wm.drag_client(Forward);
+        wm.drag_client(Forward).unwrap();
         assert_eq!(wm.focused_client().unwrap().id(), 50);
         assert_eq!(clients(&mut wm), vec![40, 30, 50, 20, 10]);
 
         wm.client_gained_focus(20);
-        wm.drag_client(Forward);
+        wm.drag_client(Forward).unwrap();
         assert_eq!(wm.focused_client().unwrap().id(), 20);
         assert_eq!(clients(&mut wm), vec![40, 30, 50, 10, 20]);
     }
@@ -1444,7 +1540,7 @@ mod tests {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
 
         add_n_clients(&mut wm, 3, 0);
-        wm.focus_workspace(&Selector::Index(1));
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
         add_n_clients(&mut wm, 2, 3);
 
         let ws_0 = Selector::Condition(&|c: &Client| c.workspace() == 0);
@@ -1459,7 +1555,7 @@ mod tests {
         let mut wm = wm_with_mock_conn(vec![], vec![]);
 
         add_n_clients(&mut wm, 3, 0);
-        wm.focus_workspace(&Selector::Index(1));
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
         add_n_clients(&mut wm, 2, 3);
 
         assert_eq!(wm.all_workspaces(&Selector::WinId(40))[0].name(), "2");
@@ -1554,34 +1650,34 @@ mod tests {
             num_screens: Cell::new(1),
         };
         let conf = Config::default();
-        let mut wm = WindowManager::new(conf, conn, vec![]);
-        wm.init();
+        let mut wm = WindowManager::new(conf, conn, vec![], logging_error_handler());
+        wm.init().unwrap();
 
         // detect_screens is called on init so should have one screen
         assert_eq!(wm.screens.len(), 1);
         assert_eq!(wm.screens.focused_unchecked().wix, 0);
 
         // Focus workspace 1 the redetect screens: should have 1 and 0
-        wm.focus_workspace(&Selector::Index(1));
+        wm.focus_workspace(&Selector::Index(1)).unwrap();
         assert_eq!(wm.screens.focused_unchecked().wix, 1);
         wm.set_num_screens(2);
-        wm.detect_screens();
+        wm.detect_screens().unwrap();
         assert_eq!(wm.screens.len(), 2);
         assert_eq!(wm.screens.get(0).unwrap().wix, 1);
         assert_eq!(wm.screens.get(1).unwrap().wix, 0);
 
         // Adding another screen should now have WS 2 as 1 is taken
         wm.set_num_screens(3);
-        wm.detect_screens();
+        wm.detect_screens().unwrap();
         assert_eq!(wm.screens.len(), 3);
         assert_eq!(wm.screens.get(0).unwrap().wix, 1);
         assert_eq!(wm.screens.get(1).unwrap().wix, 0);
         assert_eq!(wm.screens.get(2).unwrap().wix, 2);
 
         // Focus WS 3 on screen 1, drop down to 1 screen: it should still have WS 3
-        wm.focus_workspace(&Selector::Index(3));
+        wm.focus_workspace(&Selector::Index(3)).unwrap();
         wm.set_num_screens(1);
-        wm.detect_screens();
+        wm.detect_screens().unwrap();
         assert_eq!(wm.screens.len(), 1);
         assert_eq!(wm.screens.get(0).unwrap().wix, 3);
     }

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -1343,7 +1343,10 @@ impl<X: XConn> WindowManager<X> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{data_types::*, layout::*, ring::Direction::*, screen::*, xconnection::*};
+    use crate::core::{
+        data_types::*, helpers::logging_error_handler, layout::*, ring::Direction::*, screen::*,
+        xconnection::*,
+    };
 
     use std::cell::Cell;
 

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -111,9 +111,9 @@ impl<X: XConn> WindowManager<X> {
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
-     *     XcbConnection::new().unwrap(),
+     *     XcbConnection::new(true).unwrap(),
      *     vec![],
-     *     logging_error_handler()
+     *     logging_error_handler(),
      * );
      *
      * // additional set-up logic here
@@ -232,9 +232,9 @@ impl<X: XConn> WindowManager<X> {
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
-     *     XcbConnection::new().unwrap(),
+     *     XcbConnection::new(true).unwrap(),
      *     vec![],
-     *     logging_error_handler()
+     *     logging_error_handler(),
      * );
      *
      * // additional set-up logic here
@@ -343,7 +343,13 @@ impl<X: XConn> WindowManager<X> {
 
         debug!("Entering main event loop");
         while self.running {
-            if let Some(event) = self.conn.wait_for_event() {
+            let opt = if self.conn.is_non_blocking() {
+                self.conn.poll_for_event()?
+            } else {
+                Some(self.conn.wait_for_event()?)
+            };
+
+            if let Some(event) = opt {
                 debug!("Got XEvent: {:?}", event);
                 for action in process_next_event(event, self.current_state()) {
                     if let Err(e) =
@@ -717,9 +723,9 @@ impl<X: XConn> WindowManager<X> {
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
-     *     XcbConnection::new().unwrap(),
+     *     XcbConnection::new(true).unwrap(),
      *     vec![],
-     *     logging_error_handler()
+     *     logging_error_handler(),
      * );
      *
      * wm.log("hello from penrose").unwrap();
@@ -744,9 +750,9 @@ impl<X: XConn> WindowManager<X> {
      *
      * let mut wm = WindowManager::new(
      *     Config::default(),
-     *     XcbConnection::new().unwrap(),
+     *     XcbConnection::new(true).unwrap(),
      *     vec![],
-     *     logging_error_handler()
+     *     logging_error_handler(),
      * );
      *
      * if let Err(e) = wm.init() {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,7 +16,7 @@ pub mod workspace;
 pub mod xconnection;
 
 #[doc(inline)]
-pub use bindings::{FireAndForget, MouseEventHandler};
+pub use bindings::{KeyEventHandler, MouseEventHandler};
 #[doc(inline)]
 pub use client::Client;
 #[doc(inline)]

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -181,24 +181,26 @@ pub trait Draw {
     fn replace_prop(&self, id: WinId, prop: Atom, val: PropVal<'_>);
 }
 
-/// The result of calling [KeyPressDraw::next_keypress]
+/// An [XEvent] parsed into a [KeyPress] if possible, otherwise the original `XEvent`
 #[derive(Debug, Clone)]
-pub enum KeyPressResult {
-    /// The next event was parasble as a [KeyPress]
+pub enum KeyPressParseAttempt {
+    /// The event was parasble as a [KeyPress]
     KeyPress(KeyPress),
-    /// An event was received but it was not a [KeyPress]
+    /// The event was not a [KeyPress]
     XEvent(XEvent),
-    /// The event stream is now closed
-    Closed,
 }
 
 /// A [Draw] that can return the [KeyPress] events from the user for its windows
 pub trait KeyPressDraw: Draw {
-    /// Attempt to parse the next [XEvent] from an underlying connection.
+    /// Attempt to parse the next [XEvent] from an underlying connection as a [KeyPress] if there
+    /// is one.
     ///
-    /// Returns the [KeyPress] if one occured, some other [XEvent] if that is what was received or
-    /// `Closed` if there are no more events.
-    fn next_keypress(&self) -> KeyPressResult;
+    /// Should return Ok(None) if no events are currently available.
+    fn next_keypress(&self) -> Result<Option<KeyPressParseAttempt>>;
+
+    /// Wait for the next [XEvent] from an underlying connection as a [KeyPress] and attempt to
+    /// parse it as a [KeyPress].
+    fn next_keypress_blocking(&self) -> Result<KeyPressParseAttempt>;
 }
 
 /// Used for simple drawing to the screen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!         };
 //!     };
 //!
-//!     let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+//!     let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler(), true)?;
 //!     wm.grab_keys_and_run(key_bindings, map!{})
 //! }
 //!```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!         config::Config, helpers::index_selectors, manager::WindowManager,
 //!     },
 //!     xcb::new_xcb_backed_window_manager,
-//!     Backward, Forward, Less, More, Result,
+//!     Backward, Forward, Less, More, Result, logging_error_handler
 //! };
 //!
 //! fn main() -> Result<()> {
@@ -39,9 +39,8 @@
 //!         };
 //!     };
 //!
-//!     let mut wm = new_xcb_backed_window_manager(config, hooks)?;
-//!     wm.grab_keys_and_run(key_bindings, map!{});
-//!     Ok(())
+//!     let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+//!     wm.grab_keys_and_run(key_bindings, map!{})
 //! }
 //!```
 #![warn(
@@ -80,6 +79,7 @@ pub mod xcb;
 pub use crate::core::{
     config::Config,
     data_types::{Change::*, WinId},
+    helpers::logging_error_handler,
     manager::WindowManager,
     ring::{Direction::*, InsertPoint, Selector},
 };
@@ -142,3 +142,6 @@ pub enum PenroseError {
 
 /// Top level penrose Result type
 pub type Result<T> = std::result::Result<T, PenroseError>;
+
+/// A function that can be registered to handle errors that occur during [WindowManager] operation
+pub type ErrorHandler = Box<dyn FnMut(PenroseError)>;

--- a/src/xcb/draw.rs
+++ b/src/xcb/draw.rs
@@ -19,7 +19,7 @@ use pangocairo::functions::{create_layout, show_layout};
 use std::collections::HashMap;
 
 #[cfg(feature = "xcb_keysyms")]
-use crate::draw::{KeyPressDraw, KeyPressResult};
+use crate::draw::{KeyPressDraw, KeyPressParseAttempt};
 
 fn pango_layout(ctx: &cairo::Context) -> Result<pango::Layout> {
     Ok(create_layout(ctx).ok_or_else(|| XcbError::Pango("unable to create layout".into()))?)
@@ -174,8 +174,12 @@ impl Draw for XcbDraw {
 
 #[cfg(feature = "xcb_keysyms")]
 impl KeyPressDraw for XcbDraw {
-    fn next_keypress(&self) -> KeyPressResult {
-        self.api.next_keypress()
+    fn next_keypress(&self) -> Result<Option<KeyPressParseAttempt>> {
+        Ok(self.api.next_keypress()?)
+    }
+
+    fn next_keypress_blocking(&self) -> Result<KeyPressParseAttempt> {
+        Ok(self.api.next_keypress_blocking()?)
     }
 }
 

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -76,6 +76,10 @@ pub enum XcbError {
     #[error("Unhandled error: {0}")]
     Raw(String),
 
+    /// Parsing a strum generated enum from a str failed.
+    #[error(transparent)]
+    Strum(#[from] strum::ParseError),
+
     /// Screen data for an unknown screen was requested
     #[error("The requested screen index was out of bounds: {0} > {1}")]
     UnknownScreen(usize, usize),

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -1,12 +1,15 @@
 //! Helpers and utilities for using XCB as a back end for penrose
-use crate::core::{
-    bindings::{KeyCode, MouseState},
-    config::Config,
-    data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
-    hooks::{Hook, Hooks},
-    manager::WindowManager,
-    screen::Screen,
-    xconnection::{Atom, XEvent},
+use crate::{
+    core::{
+        bindings::{KeyCode, MouseState},
+        config::Config,
+        data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
+        hooks::{Hook, Hooks},
+        manager::WindowManager,
+        screen::Screen,
+        xconnection::{Atom, XEvent},
+    },
+    ErrorHandler,
 };
 
 pub mod api;
@@ -107,10 +110,11 @@ pub type XcbHooks = Hooks<XcbConnection>;
 pub fn new_xcb_backed_window_manager(
     config: Config,
     hooks: Vec<Box<dyn Hook<XcbConnection>>>,
+    error_handler: ErrorHandler,
 ) -> crate::Result<WindowManager<XcbConnection>> {
     let conn = XcbConnection::new()?;
-    let mut wm = WindowManager::new(config, conn, hooks);
-    wm.init();
+    let mut wm = WindowManager::new(config, conn, hooks, error_handler);
+    wm.init()?;
 
     Ok(wm)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use penrose::{
     core::{
-        bindings::{FireAndForget, KeyBindings, KeyCode},
+        bindings::{KeyBindings, KeyCode, KeyEventHandler},
         data_types::Region,
         layout::*,
         manager::WindowManager,
@@ -45,38 +45,38 @@ pub fn test_bindings<X: XConn>() -> KeyBindings<X> {
     let mut bindings = HashMap::new();
     bindings.insert(
         EXIT_CODE,
-        Box::new(|wm: &mut WindowManager<X>| wm.exit()) as FireAndForget<X>,
+        Box::new(|wm: &mut WindowManager<X>| wm.exit()) as KeyEventHandler<X>,
     );
     bindings.insert(
         LAYOUT_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager<X>| wm.cycle_layout(Forward)) as FireAndForget<X>,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_layout(Forward)) as KeyEventHandler<X>,
     );
     bindings.insert(
         WORKSPACE_CHANGE_CODE,
         Box::new(|wm: &mut WindowManager<X>| wm.focus_workspace(&Selector::Index(1)))
-            as FireAndForget<X>,
+            as KeyEventHandler<X>,
     );
     bindings.insert(
         ADD_WORKSPACE_CODE,
         Box::new(|wm: &mut WindowManager<X>| wm.push_workspace(Workspace::new("new", layouts())))
-            as FireAndForget<X>,
+            as KeyEventHandler<X>,
     );
     bindings.insert(
         SCREEN_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager<X>| wm.cycle_screen(Forward)) as FireAndForget<X>,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_screen(Forward)) as KeyEventHandler<X>,
     );
     bindings.insert(
         FOCUS_CHANGE_CODE,
-        Box::new(|wm: &mut WindowManager<X>| wm.cycle_client(Forward)) as FireAndForget<X>,
+        Box::new(|wm: &mut WindowManager<X>| wm.cycle_client(Forward)) as KeyEventHandler<X>,
     );
     bindings.insert(
         KILL_CLIENT_CODE,
-        Box::new(|wm: &mut WindowManager<X>| wm.kill_client()) as FireAndForget<X>,
+        Box::new(|wm: &mut WindowManager<X>| wm.kill_client()) as KeyEventHandler<X>,
     );
     bindings.insert(
         CLIENT_TO_WORKSPACE_CODE,
         Box::new(|wm: &mut WindowManager<X>| wm.client_to_workspace(&Selector::Index(1)))
-            as FireAndForget<X>,
+            as KeyEventHandler<X>,
     );
 
     bindings

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -43,14 +43,14 @@ impl StubXConn for EarlyExitConn {
         vec![common::simple_screen(0), common::simple_screen(1)]
     }
 
-    fn mock_wait_for_event(&self) -> Option<XEvent> {
+    fn mock_wait_for_event(&self) -> penrose::Result<XEvent> {
         let mut remaining = self.events.replace(vec![]);
         if remaining.is_empty() {
-            return Some(XEvent::KeyPress(common::EXIT_CODE));
+            return Ok(XEvent::KeyPress(common::EXIT_CODE));
         }
         let next = remaining.remove(0);
         self.events.set(remaining);
-        Some(next)
+        Ok(next)
     }
 
     fn mock_query_for_active_windows(&self) -> Vec<WinId> {


### PR DESCRIPTION
The main change here is making Hooks and Key / Mouse Bindings fallible.
This has the knock on effect of meaning that public methods on the
WindowManager that are intended for use as Keybindings need to return a
Result in all cases (a little disgusting) and that all Hook method impls
must return a Result. This currently leads to a lot of Ok(()) all over
the place so there is probably more tidying up to do.

While this is all going on, the XConn trait (and Draw?) should probably
also be more honest about its failure cases. At the moment, failures are
silent or swallowed in odd ways in a lot of places. The nice thing is
that the impact on user config / main.rs level code is fairly minimal so
far. More so if users are writing their own widgets / hooks / trait
impls but that is to be expected.