### PR TITLE
#107 adding compile time validation of keybindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ xcb_draw = ["cairo-rs", "cairo-sys-rs", "pango", "pangocairo"]
 xcb_keysyms = []
 
 [dependencies]
+penrose_proc = { version = "0.1.1", path = "crates/penrose_proc" }
+
 log = "0.4.8"
 nix = "0.17.0"
 strum = { version = "0.19.2", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ members = [ "crates/*" ]
 [features]
 default = ["xcb", "xcb_draw"]
 xcb_draw = ["cairo-rs", "cairo-sys-rs", "pango", "pangocairo"]
-xcb_keysyms = []
+keysyms = ["penrose_keysyms"]
 
 [dependencies]
-penrose_proc = { version = "0.1.1", path = "crates/penrose_proc" }
+penrose_keysyms = { version = "0.1.0", path = "crates/penrose_keysyms", optional = true }
+penrose_proc = { version = "0.1.2", path = "crates/penrose_proc" }
 
 log = "0.4.8"
 nix = "0.17.0"

--- a/crates/penrose_keysyms/Cargo.toml
+++ b/crates/penrose_keysyms/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "penrose_keysyms"
+version = "0.1.0"
+authors = ["IDAM <innes.andersonmorrison@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+strum = { version = "0.19.2", features = ["derive"] }
+strum_macros = "0.19.2"

--- a/crates/penrose_keysyms/src/lib.rs
+++ b/crates/penrose_keysyms/src/lib.rs
@@ -1,8 +1,6 @@
 //! Auto generated Keysym enum for use with xcb keycodes
 use strum::*;
 
-use std::convert::TryFrom;
-
 /// X keysym mappings: auto generated from X11/keysymdef.h
 #[allow(non_camel_case_types)]
 #[derive(AsRefStr, EnumString, EnumIter, Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/crates/penrose_keysyms/src/lib.rs
+++ b/crates/penrose_keysyms/src/lib.rs
@@ -1,6 +1,4 @@
 //! Auto generated Keysym enum for use with xcb keycodes
-use crate::{core::bindings::KeyPress, xcb::XcbError};
-
 use strum::*;
 
 use std::convert::TryFrom;
@@ -2667,26 +2665,5 @@ impl XKeySym {
                 .filter(|&b| b > 0)
                 .collect(),
         )?)
-    }
-}
-
-impl TryFrom<XKeySym> for KeyPress {
-    type Error = XcbError;
-
-    fn try_from(s: XKeySym) -> Result<KeyPress, XcbError> {
-        Ok(match s {
-            XKeySym::XK_Return | XKeySym::XK_KP_Enter | XKeySym::XK_ISO_Enter => KeyPress::Return,
-            XKeySym::XK_Escape => KeyPress::Escape,
-            XKeySym::XK_Tab | XKeySym::XK_ISO_Left_Tab | XKeySym::XK_KP_Tab => KeyPress::Tab,
-            XKeySym::XK_BackSpace => KeyPress::Backspace,
-            XKeySym::XK_Delete | XKeySym::XK_KP_Delete => KeyPress::Delete,
-            XKeySym::XK_Page_Up | XKeySym::XK_KP_Page_Up => KeyPress::PageUp,
-            XKeySym::XK_Page_Down | XKeySym::XK_KP_Page_Down => KeyPress::PageDown,
-            XKeySym::XK_Up | XKeySym::XK_KP_Up => KeyPress::Up,
-            XKeySym::XK_Down | XKeySym::XK_KP_Down => KeyPress::Down,
-            XKeySym::XK_Left | XKeySym::XK_KP_Left => KeyPress::Left,
-            XKeySym::XK_Right | XKeySym::XK_KP_Right => KeyPress::Right,
-            s => KeyPress::Utf8(s.as_utf8_string()?),
-        })
     }
 }

--- a/crates/penrose_proc/Cargo.toml
+++ b/crates/penrose_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_proc"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["IDAM <innes.andersonmorrison@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -20,3 +20,6 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+
+penrose_keysyms = { version = "0.1.0", path = "../penrose_keysyms" }
+strum = "0.19.2"

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -81,6 +81,8 @@ fn main() -> Result<()> {
     ];
 
     let key_bindings = gen_keybindings! {
+        validate: true;
+
         // Program launch
         "M-semicolon" => run_external!("dmenu_run");
         "M-Return" => run_external!("st");
@@ -113,9 +115,9 @@ fn main() -> Result<()> {
         "M-A-Escape" => run_internal!(exit);
 
         // setting up bindings for 6 possible workspaces
-        refmap [ 1..7 ] in {
-            "M-{}" => focus_workspace [ index_selectors(6) ];
-            "M-S-{}" => client_to_workspace [ index_selectors(6) ];
+        map: { "1", "2", "3", "4", "5", "6" } to index_selectors(6) => {
+            "M-{}" => focus_workspace (REF);
+            "M-S-{}" => client_to_workspace (REF);
         };
     };
 

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -21,6 +21,8 @@ fn main() -> Result<()> {
     let hooks = vec![];
 
     let key_bindings = gen_keybindings! {
+        validate: true;
+
         "M-j" => run_internal!(cycle_client, Forward);
         "M-k" => run_internal!(cycle_client, Backward);
         "M-S-j" => run_internal!(drag_client, Forward);
@@ -41,9 +43,9 @@ fn main() -> Result<()> {
         "M-semicolon" => run_external!("dmenu_run");
         "M-Return" => run_external!("st");
 
-        refmap [ config.ws_range() ] in {
-            "M-{}" => focus_workspace [ index_selectors(config.workspaces().len()) ];
-            "M-S-{}" => client_to_workspace [ index_selectors(config.workspaces().len()) ];
+        map: { "1", "2", "3", "4", "5", "6", "7", "8", "9" } to index_selectors(9) => {
+            "M-{}" => focus_workspace (REF);
+            "M-S-{}" => client_to_workspace (REF);
         };
     };
 

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -135,6 +135,8 @@ fn main() -> Result<()> {
      * and instead spawns a new child process.
      */
     let key_bindings = gen_keybindings! {
+        validate: true;
+
         // Program launch
         "M-semicolon" => run_external!(my_program_launcher);
         "M-Return" => run_external!(my_terminal);
@@ -169,9 +171,9 @@ fn main() -> Result<()> {
 
         // Each keybinding here will be templated in with the workspace index of each workspace,
         // allowing for common workspace actions to be bound at once.
-        refmap [ config.ws_range() ] in {
-            "M-{}" => focus_workspace [ index_selectors(config.workspaces().len()) ];
-            "M-S-{}" => client_to_workspace [ index_selectors(config.workspaces().len()) ];
+        map: { "1", "2", "3", "4", "5", "6", "7", "8", "9" } to index_selectors(9) => {
+            "M-{}" => focus_workspace (REF);
+            "M-S-{}" => client_to_workspace (REF);
         };
     };
 

--- a/src/__example_helpers.rs
+++ b/src/__example_helpers.rs
@@ -11,6 +11,7 @@ pub use crate::{
         client::Client,
         config::Config,
         data_types::{Region, ResizeAction},
+        helpers::index_selectors,
         layout::{Layout, LayoutConf},
         ring::{InsertPoint, Selector},
         screen::Screen,

--- a/src/contrib/extensions/scratchpad.rs
+++ b/src/contrib/extensions/scratchpad.rs
@@ -123,8 +123,8 @@ impl Scratchpad {
         Ok(())
     }
 
-    fn region_for_screen(&self, r: Region) -> Region {
-        let (sx, sy, sw, sh) = r.values();
+    fn region_for_screen(&self, region: Region) -> Region {
+        let (sx, sy, sw, sh) = region.values();
         let w = (sw as f32 * self.w) as u32;
         let h = (sh as f32 * self.h) as u32;
         let x = sx + (sw - w) / 2;

--- a/src/core/bindings.rs
+++ b/src/core/bindings.rs
@@ -7,6 +7,9 @@ use crate::{
     PenroseError, Result,
 };
 
+#[cfg(feature = "keysyms")]
+use penrose_keysyms::XKeySym;
+
 use std::{collections::HashMap, convert::TryFrom};
 
 use strum::EnumIter;
@@ -52,6 +55,28 @@ pub enum KeyPress {
     Left,
     /// Right
     Right,
+}
+
+#[cfg(feature = "keysyms")]
+impl TryFrom<XKeySym> for KeyPress {
+    type Error = PenroseError;
+
+    fn try_from(s: XKeySym) -> std::result::Result<KeyPress, PenroseError> {
+        Ok(match s {
+            XKeySym::XK_Return | XKeySym::XK_KP_Enter | XKeySym::XK_ISO_Enter => KeyPress::Return,
+            XKeySym::XK_Escape => KeyPress::Escape,
+            XKeySym::XK_Tab | XKeySym::XK_ISO_Left_Tab | XKeySym::XK_KP_Tab => KeyPress::Tab,
+            XKeySym::XK_BackSpace => KeyPress::Backspace,
+            XKeySym::XK_Delete | XKeySym::XK_KP_Delete => KeyPress::Delete,
+            XKeySym::XK_Page_Up | XKeySym::XK_KP_Page_Up => KeyPress::PageUp,
+            XKeySym::XK_Page_Down | XKeySym::XK_KP_Page_Down => KeyPress::PageDown,
+            XKeySym::XK_Up | XKeySym::XK_KP_Up => KeyPress::Up,
+            XKeySym::XK_Down | XKeySym::XK_KP_Down => KeyPress::Down,
+            XKeySym::XK_Left | XKeySym::XK_KP_Left => KeyPress::Left,
+            XKeySym::XK_Right | XKeySym::XK_KP_Right => KeyPress::Right,
+            s => KeyPress::Utf8(s.as_utf8_string()?),
+        })
+    }
 }
 
 /// A u16 X key-code bitmask

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@
 //!         "M-Return" => run_external!("alacritty");
 //!         "M-A-Escape" => run_internal!(exit);
 //!
-//!         refmap [ 1..10 ] in {
-//!             "M-{}" => focus_workspace [ index_selectors(9) ];
-//!             "M-S-{}" => client_to_workspace [ index_selectors(9) ];
+//!         map: { "1", "2", "3", "4", "5", "6", "7", "8", "9" } to index_selectors(9) => {
+//!             "M-{}" => focus_workspace (REF);
+//!             "M-S-{}" => client_to_workspace (REF);
 //!         };
 //!     };
 //!
@@ -151,6 +151,9 @@ pub mod xcb;
 
 #[doc(hidden)]
 pub mod __example_helpers;
+
+#[doc(hidden)]
+pub use penrose_proc::validate_user_bindings;
 
 // top level re-exports
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,10 @@ pub enum PenroseError {
     #[error("the following serialized client IDs were not known to the X server: {0:?}")]
     MissingClientIds(Vec<WinId>),
 
+    /// A conversion to utf-8 failed
+    #[error("UTF-8 error")]
+    NonUtf8Prop(#[from] std::string::FromUtf8Error),
+
     /// An [IO Error][std::io::Error] was encountered
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -13,8 +13,8 @@ use strum::*;
 
 use std::{collections::HashMap, convert::TryFrom, fmt, str::FromStr};
 
-#[cfg(feature = "xcb_keysyms")]
-use crate::{core::bindings::KeyPress, draw::KeyPressParseAttempt, xcb::keysyms::XKeySym};
+#[cfg(feature = "keysyms")]
+use crate::{core::bindings::KeyPress, draw::KeyPressParseAttempt, penrose_keysyms::XKeySym};
 
 /// A reverse lookup of KeyCode mask and value to key as a String using XKeySym mappings
 pub type ReverseCodeMap = HashMap<(KeyCodeMask, KeyCodeValue), String>;
@@ -68,7 +68,7 @@ pub struct Api {
     check_win: WinId,
     randr_base: u8,
     atoms: HashMap<Atom, u32>,
-    #[cfg(feature = "xcb_keysyms")]
+    #[cfg(feature = "keysyms")]
     code_map: ReverseCodeMap,
 }
 
@@ -96,7 +96,7 @@ impl Api {
     /// in order to prevent redundant calls through to the X server.
     ///
     /// Creating a new [Api] instance will establish the underlying connection and if
-    /// the `xcb_keysyms` feature is enabled, pull [KeyCode] mappings from the user
+    /// the `keysyms` feature is enabled, pull [KeyCode] mappings from the user
     /// system using `xmodmap`.
     ///
     /// [1]: http://rtbo.github.io/rust-xcb
@@ -109,7 +109,7 @@ impl Api {
             check_win: 0,
             randr_base: 0,
             atoms: HashMap::new(),
-            #[cfg(feature = "xcb_keysyms")]
+            #[cfg(feature = "keysyms")]
             code_map: code_map_from_xmodmap()?,
         };
         api.init()?;
@@ -191,7 +191,7 @@ impl Api {
     /// returning it as an [XKeySym] if it was a user keypress, or an [XEvent] if not.
     ///
     /// If no event is currently available, None is returned.
-    #[cfg(feature = "xcb_keysyms")]
+    #[cfg(feature = "keysyms")]
     pub fn next_keypress(&self) -> Result<Option<KeyPressParseAttempt>> {
         if let Some(event) = self.conn.poll_for_event() {
             let attempt = self.attempt_to_parse_as_keypress(event);
@@ -205,7 +205,7 @@ impl Api {
 
     /// Poll for the next event from the underlying [XCB Connection][::xcb::Connection],
     /// returning it as an [XKeySym] if it was a user keypress, or an [XEvent] if not.
-    #[cfg(feature = "xcb_keysyms")]
+    #[cfg(feature = "keysyms")]
     pub fn next_keypress_blocking(&self) -> Result<KeyPressParseAttempt> {
         loop {
             if let Some(event) = self.conn.wait_for_event() {
@@ -221,7 +221,7 @@ impl Api {
         }
     }
 
-    #[cfg(feature = "xcb_keysyms")]
+    #[cfg(feature = "keysyms")]
     fn attempt_to_parse_as_keypress(
         &self,
         event: XcbGenericEvent,

--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -14,7 +14,9 @@ use strum::*;
 use std::{collections::HashMap, convert::TryFrom, fmt, str::FromStr};
 
 #[cfg(feature = "keysyms")]
-use crate::{core::bindings::KeyPress, draw::KeyPressParseAttempt, penrose_keysyms::XKeySym};
+use crate::{core::bindings::KeyPress, draw::KeyPressParseAttempt};
+#[cfg(feature = "keysyms")]
+use penrose_keysyms::XKeySym;
 
 /// A reverse lookup of KeyCode mask and value to key as a String using XKeySym mappings
 pub type ReverseCodeMap = HashMap<(KeyCodeMask, KeyCodeValue), String>;

--- a/src/xcb/draw.rs
+++ b/src/xcb/draw.rs
@@ -18,7 +18,7 @@ use pangocairo::functions::{create_layout, show_layout};
 
 use std::collections::HashMap;
 
-#[cfg(feature = "xcb_keysyms")]
+#[cfg(feature = "keysyms")]
 use crate::draw::{KeyPressDraw, KeyPressParseAttempt};
 
 fn pango_layout(ctx: &cairo::Context) -> Result<pango::Layout> {
@@ -173,7 +173,7 @@ impl Draw for XcbDraw {
     }
 }
 
-#[cfg(feature = "xcb_keysyms")]
+#[cfg(feature = "keysyms")]
 impl KeyPressDraw for XcbDraw {
     fn next_keypress(&self) -> Result<Option<KeyPressParseAttempt>> {
         Ok(self.api.next_keypress()?)

--- a/src/xcb/helpers.rs
+++ b/src/xcb/helpers.rs
@@ -18,9 +18,8 @@ use crate::core::bindings::{CodeMap, KeyCode};
  * The user friendly patterns are parsed into a modifier mask and X key code
  * pair that is then grabbed by penrose to trigger the bound action.
  */
-pub fn parse_key_binding(pattern: impl Into<String>, known_codes: &CodeMap) -> Option<KeyCode> {
-    let s = pattern.into();
-    let mut parts: Vec<&str> = s.split('-').collect();
+pub fn parse_key_binding(pattern: String, known_codes: &CodeMap) -> Option<KeyCode> {
+    let mut parts: Vec<&str> = pattern.split('-').collect();
     match known_codes.get(parts.remove(parts.len() - 1)) {
         Some(code) => {
             let mask = parts
@@ -34,7 +33,7 @@ pub fn parse_key_binding(pattern: impl Into<String>, known_codes: &CodeMap) -> O
                 })
                 .fold(0, |acc, v| acc | v);
 
-            debug!("binding '{}' as [{}, {}]", s, mask, code);
+            debug!("binding '{}' as [{}, {}]", pattern, mask, code);
             Some(KeyCode {
                 mask: mask as u16,
                 code: *code,

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -21,8 +21,8 @@
 //! [5]: penrose_keysyms::XKeySym
 //! [6]: crate::draw::Draw
 //! [7]: crate::draw::DrawContext
-//! [7]: crate::draw::KeyPressDraw
-//! [7]: crate::xcb::XcbDraw
+//! [8]: crate::draw::KeyPressDraw
+//! [9]: crate::xcb::XcbDraw
 //! [10]: https://www.mankier.com/package/libxcb-devel
 use crate::{
     core::{

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -8,22 +8,22 @@
 //! # Available features
 //! - `xcb_draw`: adds `pango` and `cairo` as build dependencies and provides implementations of
 //!   the [Draw][6] and [DrawContext][7] traits.
-//! - `xcb_keysyms`: if enabled, this will include the [XKeySym][5] enum which is based on the
-//!   contents of `X11/keysymdef.h` and allows for parsing X keycode events as their corresponding
-//!   utf-8 representation or action.
+//! - `keysyms`: enable [KeyPressDraw][8] functionality for [XcbDraw][9]
 //!
 //! # C level documentation
 //!
-//! Docs for the underlying `xcb` C library can be found [here][8].
+//! Docs for the underlying `xcb` C library can be found [here][10].
 //!
 //! [1]: crate::core::manager::WindowManager
 //! [2]: https://xcb.freedesktop.org/
 //! [3]: https://www.pango.org/
 //! [4]: https://www.cairographics.org/
-//! [5]: crate::xcb::keysyms::XKeySym
+//! [5]: penrose_keysyms::XKeySym
 //! [6]: crate::draw::Draw
 //! [7]: crate::draw::DrawContext
-//! [8]: https://www.mankier.com/package/libxcb-devel
+//! [7]: crate::draw::KeyPressDraw
+//! [7]: crate::xcb::XcbDraw
+//! [10]: https://www.mankier.com/package/libxcb-devel
 use crate::{
     core::{
         bindings::{KeyCode, MouseState},
@@ -46,8 +46,6 @@ pub mod conversions;
 #[cfg(feature = "xcb_draw")]
 pub mod draw;
 pub mod helpers;
-#[cfg(feature = "xcb_keysyms")]
-pub mod keysyms;
 pub mod xconn;
 
 #[doc(inline)]
@@ -55,9 +53,6 @@ pub use api::Api;
 #[doc(inline)]
 #[cfg(feature = "xcb_draw")]
 pub use draw::{XcbDraw, XcbDrawContext};
-#[doc(inline)]
-#[cfg(feature = "xcb_keysyms")]
-pub use keysyms::XKeySym;
 #[doc(inline)]
 pub use xconn::XcbConnection;
 


### PR DESCRIPTION
Addresses #107 

In the end, given that the public API needs to change to allow for opting in/out of compile time validation this also deprecates the old `map` and `refmap` sections of `gen_keybindings` in favour of a single `map` section that provides a nicer end user API and also allows for these templated bindings to be validated as well.

This is done as part of the macro expansion of `gen_keybindings` itself, using `XKeySym`. Given that users will need to update their bindings to use the new macro targets, documentation and examples are being added as well.

**NOTE**: This requires bumping the version of [penrose_proc](https://crates.io/crates/penrose_proc) to version `0.1.2` and splitting `XKeySym` out to its own crate.

## Example Errors

#### An invalid keyname being used:
![2021-01-21_1611241012](https://user-images.githubusercontent.com/8116092/105367984-f4158480-5bf8-11eb-8e8f-28477ee3ffba.png)

#### An invalid set of modifier keys:
![2021-01-21_1611241161](https://user-images.githubusercontent.com/8116092/105368266-4191f180-5bf9-11eb-8e59-153db0e1b60d.png)

#### Missing keyname:
![2021-01-21_1611241239](https://user-images.githubusercontent.com/8116092/105368443-730abd00-5bf9-11eb-928f-8dfff12af556.png)

#### An invalid `map` template:
![2021-01-21_1611241529](https://user-images.githubusercontent.com/8116092/105369107-21166700-5bfa-11eb-80aa-56e614cb6578.png)

#### An invalid binding after applying a template:
![2021-01-21_1611241302](https://user-images.githubusercontent.com/8116092/105368587-9df51100-5bf9-11eb-9ef1-9e259fe87e71.png)

#### The same binding being used more than once:
![2021-01-21_1611241343](https://user-images.githubusercontent.com/8116092/105368707-b6fdc200-5bf9-11eb-95d5-0bedc930ecb3.png)
