### PR TITLE
Make XConn::atom_prop() work for arbitrary atoms

### DIFF
--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -393,12 +393,12 @@ impl XcbApi for Api {
     }
 
     // xcb docs: https://www.mankier.com/3/xcb_get_property
-    fn get_atom_prop(&self, id: WinId, atom: Atom) -> Result<u32> {
-        let a = self.known_atom(atom);
+    fn get_atom_prop(&self, id: WinId, name: &str) -> Result<u32> {
+        let a = self.atom(name)?;
         let cookie = xcb::get_property(&self.conn, false, id, a, xcb::ATOM_ANY, 0, 1024);
         let reply = cookie.get_reply()?;
         if reply.value_len() == 0 {
-            Err(XcbError::MissingProp(atom, id))
+            Err(XcbError::MissingProp(name.to_string(), id))
         } else {
             Ok(reply.value()[0])
         }

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -114,8 +114,8 @@ pub enum XcbError {
     Io(#[from] std::io::Error),
 
     /// A requested client property was empty
-    #[error("'{}' prop is not set for client {1}", .0.as_ref())]
-    MissingProp(Atom, WinId),
+    #[error("'{0}' prop is not set for client {1}")]
+    MissingProp(String, WinId),
 
     /// No screens were found
     #[error("Unable to fetch setup roots from XCB")]
@@ -198,8 +198,8 @@ pub trait XcbApi {
 
     /// Delete a known property from a window
     fn delete_prop(&self, id: WinId, prop: Atom);
-    /// Fetch an [Atom] property for a given window
-    fn get_atom_prop(&self, id: WinId, atom: Atom) -> Result<u32>;
+    /// Fetch an Atom property for a given window
+    fn get_atom_prop(&self, id: WinId, name: &str) -> Result<u32>;
     /// Fetch an String property for a given window
     fn get_str_prop(&self, id: WinId, name: &str) -> Result<String>;
     /**

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -26,7 +26,7 @@ use crate::{
     Result,
 };
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 const WM_NAME: &str = "penrose";
 
@@ -70,7 +70,7 @@ impl XcbConnection {
     }
 
     fn window_has_type_in(&self, id: WinId, win_types: &[u32]) -> bool {
-        if let Ok(atom) = self.api.get_atom_prop(id, Atom::NetWmWindowType) {
+        if let Ok(atom) = self.api.get_atom_prop(id, Atom::NetWmWindowType.as_ref()) {
             return win_types.contains(&atom);
         }
         false
@@ -328,7 +328,7 @@ impl XConn for XcbConnection {
     }
 
     fn atom_prop(&self, id: u32, name: &str) -> Result<u32> {
-        Ok(self.api.get_atom_prop(id, Atom::from_str(name)?)?)
+        Ok(self.api.get_atom_prop(id, name)?)
     }
 
     fn intern_atom(&self, atom: &str) -> Result<u32> {


### PR DESCRIPTION
Before this commit XcbConnection::atom_prop() used Atom::from_str(name)?
on its argument. Thus, it only worked for the predefined atoms. This
commit changes it to also work for arbitrary atoms. To make this work,
the XcbApi trait had to be changed accordingly.

Fixes: https://github.com/sminez/penrose/issues/112
Signed-off-by: Uli Schlachter <psychon@znc.in>