### PR TITLE
Add an x11rb backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pangocairo = { version = "0.10.0", optional = true }
 pango = { version = "0.9.1", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 xcb = { version = "0.9.0", features = ["randr"], optional = true }
-x11rb = { version = "0.8.0", optional = true }
+x11rb = { version = "0.8.0", features = ["randr"], optional = true }
 
 [dev-dependencies]
 paste = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pangocairo = { version = "0.10.0", optional = true }
 pango = { version = "0.9.1", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 xcb = { version = "0.9.0", features = ["randr"], optional = true }
+x11rb = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 paste = "1.0"

--- a/examples/draw/main.rs
+++ b/examples/draw/main.rs
@@ -9,15 +9,19 @@ use penrose::{
     },
     draw::{bar::dwm_bar, Draw, DrawContext, TextStyle},
     logging_error_handler,
-    xcb::{new_xcb_backed_window_manager, XcbDraw},
+    x11rb::{new_x11rb_rust_conn_backed_window_manager, X11rbDraw},
     Result,
 };
 
 const HEIGHT: usize = 18;
 
-const PROFONT: &str = "ProFont For Powerline";
-const FIRA: &str = "Fira Code";
-const SERIF: &str = "Serif";
+// see /usr/bin/xlsfonts for names of fonts
+//const PROFONT: &str = "ProFont For Powerline";
+//const FIRA: &str = "Fira Code";
+//const SERIF: &str = "Serif";
+const PROFONT: &str = "9x15";
+const FIRA: &str = "9x15";
+const SERIF: &str = "9x15";
 
 const BLACK: u32 = 0x282828ff;
 const GREY: u32 = 0x3c3836ff;
@@ -44,7 +48,7 @@ fn bar_draw() -> Result<()> {
     let highlight = BLUE;
     let empty_ws = GREY;
     let mut bar = dwm_bar(
-        XcbDraw::new()?,
+        X11rbDraw::new()?,
         HEIGHT,
         &style,
         highlight,
@@ -52,7 +56,7 @@ fn bar_draw() -> Result<()> {
         workspaces,
     )?;
 
-    let mut wm = new_xcb_backed_window_manager(Config::default(), vec![], logging_error_handler())?;
+    let mut wm = new_x11rb_rust_conn_backed_window_manager(Config::default(), vec![], logging_error_handler())?;
     bar.startup(&mut wm)?; // ensure widgets are initialised correctly
 
     thread::sleep(time::Duration::from_millis(1000));
@@ -67,7 +71,7 @@ fn bar_draw() -> Result<()> {
 }
 
 fn simple_draw() -> Result<()> {
-    let mut drw = XcbDraw::new()?;
+    let mut drw = X11rbDraw::new()?;
     let (_, _, w, _) = drw.screen_sizes()?[0].values();
     let id = drw.new_window(
         WinType::InputOutput(Atom::NetWindowTypeNormal),

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -21,6 +21,8 @@ use crate::core::{
 
 #[cfg(feature = "xcb")]
 use crate::xcb::XcbError;
+#[cfg(feature = "x11rb")]
+use crate::x11rb::X11rbError;
 
 use std::{convert::TryFrom, convert::TryInto};
 
@@ -48,6 +50,11 @@ pub enum DrawError {
     #[cfg(feature = "xcb")]
     #[error(transparent)]
     Xcb(#[from] XcbError),
+
+    /// Wrapper around x11rb implementation errors for [draw][crate::draw] traits
+    #[cfg(feature = "x11rb")]
+    #[error(transparent)]
+    X11rb(#[from] X11rbError),
 
     /// An attempt to use the cairo C API failed when using an XCB implementation
     /// of [Draw] or [DrawContext]
@@ -234,10 +241,13 @@ pub trait DrawContext {
     /// Clears the context
     fn clear(&mut self);
     /// Translate this context by (dx, dy) from its current position
+    // TODO: Change to &mut self
     fn translate(&self, dx: f64, dy: f64);
     /// Set the x offset for this context absolutely
+    // TODO: Change to &mut self
     fn set_x_offset(&self, x: f64);
     /// Set the y offset for this context absolutely
+    // TODO: Change to &mut self
     fn set_y_offset(&self, y: f64);
     /// Draw a filled rectangle using the current color
     fn rectangle(&self, x: f64, y: f64, w: f64, h: f64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,9 @@ pub mod draw;
 #[cfg(feature = "xcb")]
 pub mod xcb;
 
+#[cfg(feature = "x11rb")]
+pub mod x11rb;
+
 #[doc(hidden)]
 pub mod __example_helpers;
 
@@ -223,6 +226,13 @@ pub enum PenroseError {
     #[cfg(feature = "xcb")]
     #[error(transparent)]
     Xcb(#[from] crate::xcb::XcbError),
+
+    /// Something went wrong using the [x11rb] module.
+    ///
+    /// See [X11rbError][crate::x11rb::X11rbError] for variants.
+    #[cfg(feature = "x11rb")]
+    #[error(transparent)]
+    X11rb(#[from] crate::x11rb::X11rbError),
 }
 
 /// Top level penrose Result type

--- a/src/x11rb/common.rs
+++ b/src/x11rb/common.rs
@@ -1,0 +1,80 @@
+use crate::{
+    core::{
+        data_types::{PropVal, Region, WinId},
+        screen::Screen,
+        xconnection::Atom,
+    },
+    x11rb::Result as X11Result,
+};
+
+use x11rb::{
+    connection::Connection,
+    protocol::{
+        randr::ConnectionExt as _,
+        xproto::{AtomEnum, ConnectionExt as _, PropMode},
+    },
+    wrapper::ConnectionExt as _,
+};
+
+use strum::IntoEnumIterator;
+
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub(crate) struct Atoms {
+    atoms: HashMap<Atom, u32>,
+}
+
+impl Atoms {
+    pub(crate) fn new(conn: &impl Connection) -> X11Result<Self> {
+        let atoms = Atom::iter()
+            .map(|atom| Ok((atom, conn.intern_atom(false, atom.as_ref().as_bytes())?)))
+            .collect::<X11Result<Vec<_>>>()?;
+        let atoms = atoms.into_iter()
+            .map(|(atom, cookie)| Ok((atom, cookie.reply()?.atom)))
+            .collect::<X11Result<HashMap<_, _>>>()?;
+        Ok(Self { atoms })
+    }
+
+    pub(crate) fn known_atom(&self, atom: Atom) -> u32 {
+        *self.atoms.get(&atom).unwrap()
+    }
+}
+
+pub(crate) fn current_screens(conn: &impl Connection, win: WinId) -> X11Result<Vec<Screen>> {
+    let resources = conn.randr_get_screen_resources(win)?.reply()?;
+    // Send queries for all CRTCs
+    let crtcs = resources.crtcs.iter()
+        .map(|c| conn.randr_get_crtc_info(*c, 0).map_err(|err| err.into()))
+        .collect::<X11Result<Vec<_>>>()?;
+    // Get the replies and construct screens
+    let screens = crtcs.into_iter()
+        .flat_map(|cookie| cookie.reply().ok())
+        .enumerate()
+        .filter(|(_, reply)| reply.width > 0)
+        .map(|(i, reply)| {
+            let region = Region::new(
+                reply.x as u32,
+                reply.y as u32,
+                reply.width as u32,
+                reply.height as u32,
+            );
+            Screen::new(region, i)
+        })
+        .collect();
+    Ok(screens)
+}
+
+pub(crate) fn replace_prop(conn: &impl Connection, win: WinId, prop: u32, val: PropVal<'_>) -> X11Result<()> {
+    let (kind, data) = match val {
+        PropVal::Atom(data) => (AtomEnum::ATOM, data),
+        PropVal::Cardinal(data) => (AtomEnum::CARDINAL, data),
+        PropVal::Window(data) => (AtomEnum::WINDOW, data),
+        PropVal::Str(s) => {
+            conn.change_property8(PropMode::REPLACE, win, prop, AtomEnum::STRING, s.as_bytes())?;
+            return Ok(())
+        }
+    };
+    conn.change_property32(PropMode::REPLACE, win, prop, kind, data)?;
+    Ok(())
+}

--- a/src/x11rb/draw.rs
+++ b/src/x11rb/draw.rs
@@ -1,0 +1,272 @@
+//! API layer implementing [Draw][crate::draw::Draw] and [DrawContext][crate::draw::DrawContext]
+//! using just x11rb.
+
+use crate::{
+    core::{
+        data_types::{PropVal, Region, WinId, WinType},
+        xconnection::Atom,
+    },
+    draw::{Color, Draw, DrawContext, DrawError, Result},
+    x11rb::{common::{current_screens, replace_prop, Atoms}, Result as X11Result, X11rbError},
+};
+
+use x11rb::{
+    connection::Connection,
+    protocol::xproto::{
+        AtomEnum, Char2b, ChangeGCAux, CreateGCAux, CreateWindowAux, ConnectionExt as _, EventMask,
+        Font, Gcontext, PropMode, Rectangle, WindowClass,
+    },
+    rust_connection::RustConnection,
+    wrapper::ConnectionExt,
+};
+
+use std::{
+    cell::Cell,
+    collections::HashMap,
+    rc::Rc,
+};
+
+/// An x11rb based [Draw] implementation that directly does X11 drawing.
+///
+/// Expect bad text output!
+#[derive(Debug)]
+pub struct X11rbDraw<C> {
+    conn: Rc<C>,
+    atoms: Atoms,
+    fonts: HashMap<String, Font>,
+}
+
+impl X11rbDraw<RustConnection> {
+    /// Create a new empty [X11rbDraw]. Fails if unable to connect to the X server.
+    pub fn new() -> Result<Self> {
+        let (conn, _) = RustConnection::connect(None).map_err(|err| X11rbError::from(err))?;
+        Ok(Self::new_for_connection(Rc::new(conn))?)
+    }
+}
+
+impl<C: Connection> X11rbDraw<C> {
+    /// Create a new empty [X11rbDraw] for the given X connection.
+    pub fn new_for_connection(conn: Rc<C>) -> Result<Self> {
+        let atoms = Atoms::new(&*conn)?;
+        Ok(Self {
+            conn,
+            atoms,
+            fonts: HashMap::new(),
+        })
+    }
+}
+
+impl<C: Connection> Draw for X11rbDraw<C> {
+    type Ctx = X11rbDrawContext<C>;
+
+    fn new_window(&mut self, ty: WinType, r: Region, managed: bool) -> Result<WinId> {
+        let id = self.conn.generate_id().map_err(|err| X11rbError::from(err))?;
+        let screen = &self.conn.setup().roots[0];
+        let (x, y, w, h) = r.values();
+        let mut aux = CreateWindowAux::new();
+        let mut kind = None;
+        let class;
+
+        if !managed {
+            aux = aux.override_redirect(1);
+        }
+
+        match ty {
+            WinType::CheckWin => class = WindowClass::INPUT_OUTPUT,
+            WinType::InputOnly => class = WindowClass::INPUT_ONLY,
+            WinType::InputOutput(a) => {
+                let window_type = self.conn.intern_atom(false, Atom::NetWmWindowType.as_ref().as_bytes())
+                    .map_err(|err| X11rbError::from(err))?;
+                let atom = self.conn.intern_atom(false, a.as_ref().as_bytes())
+                    .map_err(|err| X11rbError::from(err))?;
+                let window_type = window_type.reply()
+                    .map_err(|err| X11rbError::from(err))?
+                    .atom;
+                let atom = atom.reply()
+                    .map_err(|err| X11rbError::from(err))?
+                    .atom;
+                class = WindowClass::INPUT_OUTPUT;
+                kind = Some((window_type, atom));
+                aux = aux.border_pixel(screen.black_pixel)
+                    .event_mask(EventMask::EXPOSURE | EventMask::KEY_PRESS);
+            }
+        }
+
+        self.conn.create_window(
+            x11rb::COPY_DEPTH_FROM_PARENT, // depth
+            id,
+            screen.root,
+            x as _,
+            y as _,
+            w as _,
+            h as _,
+            0, // border width
+            class,
+            x11rb::COPY_FROM_PARENT,
+            &aux,
+        ).map_err(|err| X11rbError::from(err))?;
+
+        if let Some((window_type, atom)) = kind {
+            self.conn.change_property32(PropMode::REPLACE, id, window_type, AtomEnum::ATOM, &[atom])
+                .map_err(|err| X11rbError::from(err))?;
+            self.conn.map_window(id)
+                .map_err(|err| X11rbError::from(err))?;
+        }
+
+        Ok(id)
+    }
+
+    fn screen_sizes(&self) -> Result<Vec<Region>> {
+        let root = self.conn.setup().roots[0].root;
+        Ok(current_screens(&*self.conn, root)?
+            .into_iter()
+            .map(|s| s.region(false))
+            .collect())
+    }
+
+    fn register_font(&mut self, font_name: &str) {
+        let font = self.conn.generate_id().unwrap();
+        self.conn.open_font(font, font_name.as_bytes()).unwrap();
+        self.fonts.insert(font_name.to_string(), font);
+    }
+
+    fn context_for(&self, id: WinId) -> Result<Self::Ctx> {
+        Ok(X11rbDrawContext::new(Rc::clone(&self.conn), id, self.fonts.clone())?)
+    }
+
+    fn temp_context(&self, w: u32, h: u32) -> Result<Self::Ctx> {
+        let _ = (w, h);
+        todo!()
+    }
+
+    fn flush(&self, _id: WinId) {
+        self.conn.flush().unwrap();
+    }
+
+    fn map_window(&self, id: WinId) {
+        self.conn.map_window(id).unwrap();
+    }
+
+    fn unmap_window(&self, id: WinId) {
+        self.conn.unmap_window(id).unwrap();
+    }
+
+    fn destroy_window(&mut self, id: WinId) {
+        self.conn.destroy_window(id).unwrap();
+    }
+
+    fn replace_prop(&self, id: WinId, prop: Atom, val: PropVal<'_>) {
+        let atom = self.atoms.known_atom(prop);
+        replace_prop(&*self.conn, id, atom, val).unwrap();
+    }
+}
+
+/// An x11rb based drawing context that directly does X11 drawing.
+///
+/// Expect bad text output!
+#[derive(Debug)]
+pub struct X11rbDrawContext<C> {
+    conn: Rc<C>,
+    gc: Gcontext,
+    target: WinId,
+    // FIXME: This Cell is a work-around that should be fixed in the DrawContext trait instead (&self vs &mut self)
+    offset: Cell<(f64, f64)>,
+    font: Option<Font>,
+    fonts: HashMap<String, Font>,
+}
+
+impl<C: Connection> X11rbDrawContext<C> {
+    fn new(conn: Rc<C>, target: WinId, fonts: HashMap<String, Font>) -> X11Result<Self> {
+        let gc = conn.generate_id()?;
+        conn.create_gc(gc, target, &CreateGCAux::new())?;
+        Ok(Self {
+            conn,
+            gc,
+            target,
+            offset: Cell::new((0., 0.)),
+            font: None,
+            fonts,
+        })
+    }
+
+    fn coords(&self, x: f64, y: f64) -> (i16, i16) {
+        let (dx, dy) = self.offset.get();
+        ((dx + x).ceil() as _, (dy + y).ceil() as _)
+    }
+}
+
+impl<C: Connection> DrawContext for X11rbDrawContext<C> {
+    fn font(&mut self, font_name: &str, point_size: i32) -> Result<()> {
+        let font = *self.fonts.get(font_name).ok_or_else(|| DrawError::UnknownFont(font_name.to_string()))?;
+        warn!("X11 core fonts do not have a separate point size argument, ignoring {}", point_size);
+        self.conn.change_gc(self.gc, &ChangeGCAux::new().font(font)).unwrap();
+        self.font = Some(font);
+        Ok(())
+    }
+
+    fn color(&mut self, color: &Color) {
+        // FIXME: use RENDER instead of core rendering
+        // FIXME: The following is incorrect, but good enough for now
+        // FIXME: This kind of code should be on Color and not here (at least partly)
+        let (r, g, b) = color.rgb();
+        let (r, g, b) = (r * 255., g * 255., b * 255.);
+        let (r, g, b) = (r as u8 as u32, g as u8 as u32, b as u8 as u32);
+        let pixel = (r << 16) | (g << 8) | b;
+        self.conn.change_gc(self.gc, &ChangeGCAux::new().foreground(pixel)).unwrap();
+    }
+
+    fn clear(&mut self) {
+        // FIXME: This only works for windows and not for drawables
+        self.conn.clear_area(false, self.target, 0, 0, 0, 0).unwrap();
+    }
+
+    fn translate(&self, dx: f64, dy: f64) {
+        let (x, y) = self.offset.get();
+        self.offset.set((x + dx, y + dy));
+    }
+
+    fn set_x_offset(&self, x: f64) {
+        let (_, y) = self.offset.get();
+        self.offset.set((x, y));
+    }
+
+    fn set_y_offset(&self, y: f64) {
+        let (x, _) = self.offset.get();
+        self.offset.set((x, y));
+    }
+
+    fn rectangle(&self, x: f64, y: f64, w: f64, h: f64) {
+        // FIXME: Get rid of the rounding and use RENDER instead
+        let (x, y) = self.coords(x, y);
+        let (width, height) = (w.floor() as u16, h.floor() as u16);
+        let rect = Rectangle { x, y, width, height };
+        self.conn.poly_rectangle(self.target, self.gc, &[rect]).unwrap();
+    }
+
+    fn text(&self, s: &str, h_offset: f64, padding: (f64, f64)) -> Result<(f64, f64)> {
+        let (w, h) = self.text_extent(s)?;
+        let (x, y) = self.coords(padding.0, h_offset);
+        // FIXME: Using utf8 is not correct here, but at least ASCII should still work
+        // FIXME: This also draws a background with the current background color
+        self.conn.image_text8(self.target, self.gc, x, y, s.as_bytes())
+            .map_err(|err| X11rbError::from(err))?;
+        Ok((w + padding.0 + padding.1, h))
+    }
+
+    fn text_extent(&self, s: &str) -> Result<(f64, f64)> {
+        // FIXME: Using utf8 is not correct here, but at least ASCII should still work
+        let text = s.bytes().map(|b| Char2b { byte1: b, byte2: 0 }).collect::<Vec<_>>();
+        let extents = self.conn.query_text_extents(self.font.unwrap(), &text)
+            .map_err(|err| X11rbError::from(err))?
+            .reply()
+            .map_err(|err| X11rbError::from(err))?;
+        // FIXME No idea if this is correct
+        let width = extents.overall_width;
+        let height = extents.overall_ascent + extents.overall_descent;
+        Ok((width as _, height as _))
+    }
+
+    fn flush(&self) {
+        self.conn.flush().unwrap();
+    }
+}

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -13,10 +13,15 @@ use crate::{
 
 use x11rb::rust_connection::RustConnection;
 
+pub(crate) mod common;
+// TODO: #[cfg(feature = "x11rb_draw")]
+pub mod draw;
 pub mod xconn;
 
 #[doc(inline)]
 pub use xconn::X11rbConnection;
+
+pub use draw::{X11rbDraw, X11rbDrawContext};
 
 /// Result type for fallible methods using x11rb
 pub type Result<T> = std::result::Result<T, X11rbError>;

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -1,11 +1,39 @@
 //! Helpers and utilities for using x11rb as a back end for penrose
 
-use crate::core::{data_types::WinId, xconnection::Atom};
+use crate::{
+    core::{
+        config::Config,
+        data_types::WinId,
+        hooks::Hook,
+        manager::WindowManager,
+        xconnection::Atom,
+    },
+    ErrorHandler,
+};
+
+use x11rb::rust_connection::RustConnection;
 
 pub mod xconn;
 
+#[doc(inline)]
+pub use xconn::X11rbConnection;
+
 /// Result type for fallible methods using x11rb
 pub type Result<T> = std::result::Result<T, X11rbError>;
+
+/// Construct a penrose [WindowManager] backed by the default [x11rb][crate::x11rb] backend.
+pub fn new_x11rb_backed_window_manager(
+    config: Config,
+    hooks: Vec<Box<dyn Hook<X11rbConnection<RustConnection>>>>,
+    error_handler: ErrorHandler,
+) -> crate::Result<WindowManager<X11rbConnection<RustConnection>>> {
+    let (inner_conn, _) = RustConnection::connect(None).map_err(|err| X11rbError::from(err))?;
+    let conn = X11rbConnection::new_for_connection(inner_conn)?;
+    let mut wm = WindowManager::new(config, conn, hooks, error_handler);
+    wm.init()?;
+
+    Ok(wm)
+}
 
 /// Enum to store the various ways that operations can fail inside of the
 /// x11rb implementations of penrose traits.

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -1,0 +1,29 @@
+//! TODO: Docs
+
+use crate::core::{data_types::WinId, xconnection::Atom};
+
+pub mod xconn;
+
+/// Result type for fallible methods using x11rb
+pub type Result<T> = std::result::Result<T, X11rbError>;
+
+/// Enum to store the various ways that operations can fail inside of the
+/// x11rb implementations of penrose traits.
+#[derive(thiserror::Error, Debug)]
+pub enum X11rbError {
+    /// Unable to establish a connection to the X server
+    #[error(transparent)]
+    Connect(#[from] ::x11rb::errors::ConnectError),
+
+    /// The X11 connection broke
+    #[error(transparent)]
+    Connection(#[from] ::x11rb::errors::ConnectionError),
+
+    /// Could not get X11 request reply
+    #[error(transparent)]
+    ReplyError(#[from] ::x11rb::errors::ReplyError),
+
+    /// A requested client property was empty
+    #[error("'{}' prop is not set for client {1}", .0.as_ref())]
+    MissingProp(Atom, WinId),
+}

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -23,7 +23,15 @@ pub enum X11rbError {
     #[error(transparent)]
     ReplyError(#[from] ::x11rb::errors::ReplyError),
 
+    /// Could not get X11 request reply or could not generate_id()
+    #[error(transparent)]
+    ReplyOrIdError(#[from] ::x11rb::errors::ReplyOrIdError),
+
     /// A requested client property was empty
     #[error("'{}' prop is not set for client {1}", .0.as_ref())]
     MissingProp(Atom, WinId),
+
+    /// The X11 server does not support the RandR extension
+    #[error("the X11 server does not support the RandR extension")]
+    MissingRandRSupport,
 }

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -1,4 +1,4 @@
-//! TODO: Docs
+//! Helpers and utilities for using x11rb as a back end for penrose
 
 use crate::core::{data_types::WinId, xconnection::Atom};
 

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -22,13 +22,24 @@ pub use xconn::X11rbConnection;
 pub type Result<T> = std::result::Result<T, X11rbError>;
 
 /// Construct a penrose [WindowManager] backed by the default [x11rb][crate::x11rb] backend.
-pub fn new_x11rb_backed_window_manager(
+pub fn new_x11rb_rust_conn_backed_window_manager(
     config: Config,
     hooks: Vec<Box<dyn Hook<X11rbConnection<RustConnection>>>>,
     error_handler: ErrorHandler,
 ) -> crate::Result<WindowManager<X11rbConnection<RustConnection>>> {
-    let (inner_conn, _) = RustConnection::connect(None).map_err(|err| X11rbError::from(err))?;
-    let conn = X11rbConnection::new_for_connection(inner_conn)?;
+    let (conn, _) = RustConnection::connect(None).map_err(|err| X11rbError::from(err))?;
+    new_x11rb_backed_window_manager(conn, config, hooks, error_handler)
+}
+
+/// Construct a penrose [WindowManager] backed by the default [x11rb][crate::x11rb] backend with
+/// the given connection.
+pub fn new_x11rb_backed_window_manager<C: x11rb::connection::Connection>(
+    connection: C,
+    config: Config,
+    hooks: Vec<Box<dyn Hook<X11rbConnection<C>>>>,
+    error_handler: ErrorHandler,
+) -> crate::Result<WindowManager<X11rbConnection<C>>> {
+    let conn = X11rbConnection::new_for_connection(connection)?;
     let mut wm = WindowManager::new(config, conn, hooks, error_handler);
     wm.init()?;
 

--- a/src/x11rb/xconn.rs
+++ b/src/x11rb/xconn.rs
@@ -1,0 +1,318 @@
+//! TODO: Docs
+
+use crate::{
+    PenroseError,
+    core::{
+        bindings::{KeyBindings, MouseBindings},
+        data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
+        manager::WindowManager,
+        screen::Screen,
+        xconnection::{
+            Atom, XConn, XEvent, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS,
+            UNMANAGED_WINDOW_TYPES,
+        },
+    },
+    x11rb::{Result as X11Result, X11rbError},
+    Result,
+};
+
+use x11rb::{
+    connection::Connection,
+    properties::WmClass,
+    protocol::xproto::{
+        AtomEnum, ChangeWindowAttributesAux, ConfigureWindowAux, ConnectionExt as _, EventMask,
+        InputFocus, PropMode, StackMode, Window,
+    },
+    wrapper::ConnectionExt as _,
+};
+
+use strum::IntoEnumIterator;
+
+use std::{
+    collections::HashMap,
+    str::FromStr,
+};
+
+#[derive(Debug)]
+pub struct X11rbConnection<C> {
+    conn: C,
+    root: Window,
+    atoms: HashMap<Atom, u32>,
+    auto_float_types: Vec<u32>,
+    dont_manage_types: Vec<u32>,
+}
+
+impl<C> X11rbConnection<C>
+where
+    C: Connection,
+{
+    pub fn new_for_connection(conn: C) -> Result<Self> {
+        let root = conn.setup().roots[0].root;
+        let atoms = Atom::iter()
+            .map(|atom| Ok((atom, conn.intern_atom(false, atom.as_ref().as_bytes())?)))
+            .collect::<X11Result<Vec<_>>>()?;
+        let atoms = atoms.into_iter()
+            .map(|(atom, cookie)| Ok((atom, cookie.reply()?.atom)))
+            .collect::<X11Result<HashMap<_, _>>>()?;
+        let auto_float_types = AUTO_FLOAT_WINDOW_TYPES
+            .iter()
+            .map(|a| *atoms.get(&a).unwrap())
+            .collect();
+        let dont_manage_types = UNMANAGED_WINDOW_TYPES
+            .iter()
+            .map(|a| *atoms.get(&a).unwrap())
+            .collect();
+        Ok(X11rbConnection {
+            conn,
+            root,
+            atoms,
+            auto_float_types,
+            dont_manage_types,
+        })
+    }
+
+    fn known_atom(&self, atom: Atom) -> u32 {
+        *self.atoms.get(&atom).unwrap()
+    }
+
+    fn window_has_type_in(&self, id: WinId, win_types: &[u32]) -> bool {
+        self.conn.get_property(false, id, self.known_atom(Atom::NetWmWindowType), AtomEnum::ANY, 0, 1024)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .as_ref()
+            .and_then(|reply| reply.value32())
+            .and_then(|mut iter| iter.next())
+            .map(|atom| win_types.contains(&atom))
+            .unwrap_or(false)
+    }
+}
+
+impl<C> XConn for X11rbConnection<C>
+where
+    C: Connection,
+{
+    #[cfg(feature = "serde")]
+    fn hydrate(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    fn flush(&self) -> bool {
+        self.conn.flush().is_ok()
+    }
+
+    fn wait_for_event(&self) -> Result<XEvent> {
+        todo!()
+    }
+
+    fn current_outputs(&self) -> Vec<Screen> {
+        todo!()
+    }
+
+    fn cursor_position(&self) -> Point {
+        self.conn.query_pointer(self.root)
+            .ok()
+            .and_then(|c| c.reply().ok())
+            .map(|reply| Point::new(reply.root_x as u32, reply.root_y as u32))
+            .unwrap_or_else(|| Point::new(0, 0))
+    }
+
+    fn position_window(&self, id: WinId, r: Region, border: u32, stack_above: bool) {
+        let (x, y, w, h) = r.values();
+        let mut aux = ConfigureWindowAux::new()
+            .border_width(border)
+            .x(x as i32)
+            .y(y as i32)
+            .width(w)
+            .height(h);
+        if stack_above {
+            aux = aux.stack_mode(StackMode::ABOVE);
+        }
+        self.conn.configure_window(id, &aux).unwrap();
+    }
+
+    fn raise_window(&self, id: WinId) {
+        let aux = ConfigureWindowAux::new()
+            .stack_mode(StackMode::ABOVE);
+        self.conn.configure_window(id, &aux).unwrap();
+    }
+
+    fn mark_new_window(&self, id: WinId) {
+        let mask = EventMask::ENTER_WINDOW
+            | EventMask::LEAVE_WINDOW
+            | EventMask::PROPERTY_CHANGE
+            | EventMask::STRUCTURE_NOTIFY;
+        let aux = ChangeWindowAttributesAux::new().event_mask(mask);
+        self.conn.change_window_attributes(id, &aux).unwrap();
+    }
+
+    fn map_window(&self, id: WinId) {
+        self.conn.map_window(id).unwrap();
+    }
+
+    fn unmap_window(&self, id: WinId) {
+        self.conn.unmap_window(id).unwrap();
+    }
+
+    fn send_client_event(&self, id: WinId, atom_name: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn focused_client(&self) -> WinId {
+        self.conn.get_input_focus()
+            .ok()
+            .and_then(|c| c.reply().ok())
+            .map(|reply| reply.focus)
+            .unwrap_or(0)
+    }
+
+    fn focus_client(&self, id: WinId) {
+        // FIXME: This ignores WM_PROTOCOLS and WM_HINTS (same for crate::xcb::api::mark_focused_window())
+        self.conn.set_input_focus(InputFocus::PARENT, id, x11rb::CURRENT_TIME).unwrap();
+
+        let atom = self.known_atom(Atom::NetActiveWindow);
+        self.conn.change_property32(PropMode::REPLACE, id, atom, AtomEnum::WINDOW, &[id]).unwrap();
+    }
+
+    fn set_client_border_color(&self, id: WinId, color: u32) {
+        let aux = ChangeWindowAttributesAux::new().border_pixel(color);
+        self.conn.change_window_attributes(id, &aux).unwrap();
+    }
+
+    fn grab_keys(&self, key_bindings: &KeyBindings<Self>, mouse_bindings: &MouseBindings<Self>) {
+        todo!()
+    }
+
+    fn set_wm_properties(&self, workspaces: &[&str]) {
+        todo!()
+    }
+
+    fn update_desktops(&self, workspaces: &[&str]) {
+        let num_desktops = self.known_atom(Atom::NetNumberOfDesktops);
+        let desktop_names = self.known_atom(Atom::NetDesktopNames);
+        let workspace_names = workspaces.join("\0");
+        self.conn.change_property32(PropMode::REPLACE, self.root, num_desktops, AtomEnum::CARDINAL, &[workspaces.len() as u32]).unwrap();
+        self.conn.change_property8(PropMode::REPLACE, self.root, desktop_names, AtomEnum::STRING, workspace_names.as_bytes()).unwrap();
+    }
+
+    fn update_known_clients(&self, clients: &[WinId]) {
+        let list = self.known_atom(Atom::NetClientList);
+        let list_stacking = self.known_atom(Atom::NetClientListStacking);
+        self.conn.change_property32(PropMode::REPLACE, self.root, list, AtomEnum::WINDOW, clients).unwrap();
+        self.conn.change_property32(PropMode::REPLACE, self.root, list_stacking, AtomEnum::WINDOW, clients).unwrap();
+    }
+
+    fn set_current_workspace(&self, wix: usize) {
+        let desktop = self.known_atom(Atom::NetCurrentDesktop);
+        self.conn.change_property32(PropMode::REPLACE, self.root, desktop, AtomEnum::CARDINAL, &[wix as u32]).unwrap();
+    }
+
+    fn set_root_window_name(&self, name: &str) {
+        self.conn.change_property8(PropMode::REPLACE, self.root, AtomEnum::WM_NAME, AtomEnum::STRING, name.as_bytes()).unwrap();
+    }
+
+    fn set_client_workspace(&self, id: WinId, wix: usize) {
+        let desktop = self.known_atom(Atom::NetWmDesktop);
+        self.conn.change_property32(PropMode::REPLACE, self.root, desktop, AtomEnum::CARDINAL, &[wix as u32]).unwrap();
+    }
+
+    fn toggle_client_fullscreen(&self, id: WinId, client_is_fullscreen: bool) {
+        let fullscreen = [self.known_atom(Atom::NetWmStateFullscreen)];
+        let data: &[u32] = if client_is_fullscreen {
+            &fullscreen
+        } else {
+            &[]
+        };
+        let wm_state = self.known_atom(Atom::NetWmState);
+        self.conn.change_property32(PropMode::REPLACE, id, wm_state, AtomEnum::ATOM, &data).unwrap();
+    }
+
+    fn window_should_float(&self, id: WinId, floating_classes: &[&str]) -> bool {
+        if WmClass::get(&self.conn, id)
+                .ok()
+                .and_then(|cookie| cookie.reply_unchecked().ok().flatten())
+                .as_ref()
+                .and_then(|class| std::str::from_utf8(class.class()).ok())
+                .map(|class| floating_classes.contains(&class))
+                .unwrap_or(false) {
+            return true;
+        }
+        self.window_has_type_in(id, &self.auto_float_types)
+    }
+
+    fn is_managed_window(&self, id: WinId) -> bool {
+        !self.window_has_type_in(id, &self.dont_manage_types)
+    }
+
+    fn window_geometry(&self, id: WinId) -> Result<Region> {
+        fn window_geometry_impl(conn: &impl Connection, id: WinId) -> X11Result<Region> {
+            let geo = conn.get_geometry(id)?.reply()?;
+            Ok(Region::new(geo.x as _, geo.y as _, geo.width as _, geo.height as _))
+        }
+        Ok(window_geometry_impl(&self.conn, id)?)
+    }
+
+    fn warp_cursor(&self, id: Option<WinId>, screen: &Screen) {
+        let (x, y, id) = match id {
+            Some(id) => {
+                let (_, _, w, h) = match self.window_geometry(id) {
+                    Ok(region) => region.values(),
+                    Err(e) => {
+                        error!("error fetching window details while warping cursor: {}", e);
+                        return;
+                    }
+                };
+                ((w / 2), (h / 2), id)
+            }
+            None => {
+                let (x, y, w, h) = screen.region(true).values();
+                ((x + w / 2), (y + h / 2), self.root)
+            }
+        };
+        self.conn.warp_pointer(x11rb::NONE, id, 0, 0, 0, 0, x as _, y as _).unwrap();
+    }
+
+    fn query_for_active_windows(&self) -> Vec<WinId> {
+        todo!()
+    }
+
+    fn str_prop(&self, id: u32, name: &str) -> Result<String> {
+        fn str_prop_impl(conn: &impl Connection, id: u32, atom: u32) -> X11Result<Vec<u8>> {
+            Ok(conn.get_property(false, id, atom, AtomEnum::ANY, 0, 1024)?
+                .reply()?
+                .value)
+        }
+        let atom = self.intern_atom(name)?;
+        let value = str_prop_impl(&self.conn, id, atom)?;
+        Ok(String::from_utf8(value)?)
+    }
+
+    fn atom_prop(&self, id: u32, name: &str) -> Result<u32> {
+        fn atom_prop_impl(conn: &impl Connection, id: u32, atom: u32) -> X11Result<Option<u32>> {
+            Ok(conn.get_property(false, id, atom, AtomEnum::ANY, 0, 1024)?
+                .reply()?
+                .value32()
+                .and_then(|mut iter| iter.next()))
+        }
+        // FIXME: If this API only supports atoms from Atom, then why does it get a &str?
+        let atom = Atom::from_str(name)?;
+        let value = atom_prop_impl(&self.conn, id, self.known_atom(atom))?;
+        value.ok_or(PenroseError::X11rb(X11rbError::MissingProp(atom, id)))
+    }
+
+    fn intern_atom(&self, atom: &str) -> Result<u32> {
+        if let Ok(known) = Atom::from_str(atom) {
+            Ok(self.known_atom(known))
+        } else {
+            fn intern_atom_impl(conn: &impl Connection, atom: &str) -> X11Result<u32> {
+                Ok(conn.intern_atom(false, atom.as_bytes())?
+                    .reply()?
+                    .atom)
+            }
+            Ok(intern_atom_impl(&self.conn, atom)?)
+        }
+    }
+
+    fn cleanup(&self) {
+        todo!()
+    }
+}

--- a/src/x11rb/xconn.rs
+++ b/src/x11rb/xconn.rs
@@ -3,9 +3,11 @@
 use crate::{
     PenroseError,
     core::{
-        bindings::{KeyBindings, MouseBindings},
-        data_types::{Point, PropVal, Region, WinAttr, WinConfig, WinId, WinType},
-        manager::WindowManager,
+        bindings::{
+            KeyBindings, KeyCode, ModifierKey, MouseBindings, MouseButton, MouseEvent,
+            MouseEventKind, MouseState,
+        },
+        data_types::{Point, Region, WinId},
         screen::Screen,
         xconnection::{
             Atom, XConn, XEvent, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS,
@@ -19,9 +21,14 @@ use crate::{
 use x11rb::{
     connection::Connection,
     properties::WmClass,
-    protocol::xproto::{
-        AtomEnum, ChangeWindowAttributesAux, ConfigureWindowAux, ConnectionExt as _, EventMask,
-        InputFocus, PropMode, StackMode, Window,
+    protocol::{
+        randr::{self, ConnectionExt as _},
+        xproto::{
+            AtomEnum, ChangeWindowAttributesAux, ClientMessageEvent, ConfigureWindowAux,
+            ConnectionExt as _, CreateWindowAux, EventMask, GrabMode, InputFocus, ModMask,
+            PropMode, StackMode, Window, WindowClass, CLIENT_MESSAGE_EVENT,
+        },
+        Event,
     },
     wrapper::ConnectionExt as _,
 };
@@ -37,6 +44,7 @@ use std::{
 pub struct X11rbConnection<C> {
     conn: C,
     root: Window,
+    check_win: Window,
     atoms: HashMap<Atom, u32>,
     auto_float_types: Vec<u32>,
     dont_manage_types: Vec<u32>,
@@ -48,12 +56,17 @@ where
 {
     pub fn new_for_connection(conn: C) -> Result<Self> {
         let root = conn.setup().roots[0].root;
+        conn.prefetch_extension_information(randr::X11_EXTENSION_NAME)
+            .map_err(|err| X11rbError::from(err))?;
+
+        // Setup atoms: First send all InternAtom requests and then fetch the replies
         let atoms = Atom::iter()
             .map(|atom| Ok((atom, conn.intern_atom(false, atom.as_ref().as_bytes())?)))
             .collect::<X11Result<Vec<_>>>()?;
         let atoms = atoms.into_iter()
             .map(|(atom, cookie)| Ok((atom, cookie.reply()?.atom)))
             .collect::<X11Result<HashMap<_, _>>>()?;
+
         let auto_float_types = AUTO_FLOAT_WINDOW_TYPES
             .iter()
             .map(|a| *atoms.get(&a).unwrap())
@@ -62,9 +75,30 @@ where
             .iter()
             .map(|a| *atoms.get(&a).unwrap())
             .collect();
+
+        // Setup the RandR extension
+        if conn.extension_information(randr::X11_EXTENSION_NAME)
+                .map_err(|err| X11rbError::from(err))?
+                .is_none() {
+            return Err(X11rbError::MissingRandRSupport.into());
+        }
+        use randr::NotifyMask;
+        let mask = NotifyMask::OUTPUT_CHANGE | NotifyMask::CRTC_CHANGE | NotifyMask::SCREEN_CHANGE;
+        conn.randr_select_input(root, mask).map_err(|err| X11rbError::from(err))?;
+
+        // Setup the check win
+        let check_win = conn.generate_id().map_err(|err| X11rbError::from(err))?;
+        let aux = CreateWindowAux::new().override_redirect(1);
+        let (x, y, w, h, border, visual) = (0, 0, 1, 1, 0, 0);
+        conn.create_window(0, check_win, root, x, y, w, h, border, WindowClass::INPUT_OUTPUT, visual, &aux)
+            .map_err(|err| X11rbError::from(err))?;
+
+        // TODO: Check the version of the RandR extension supported by the server.
+        // It might be too old.
         Ok(X11rbConnection {
             conn,
             root,
+            check_win,
             atoms,
             auto_float_types,
             dont_manage_types,
@@ -85,6 +119,15 @@ where
             .map(|atom| win_types.contains(&atom))
             .unwrap_or(false)
     }
+
+    fn get_atom_name(&self, atom: u32) -> Option<String> {
+        // FIXME: We could scan our known atoms first. Iterating through the values of
+        // a HashMap should still be faster than querying the X11 server.
+        self.conn.get_atom_name(atom)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .and_then(|reply| String::from_utf8(reply.name).ok())
+    }
 }
 
 impl<C> XConn for X11rbConnection<C>
@@ -101,11 +144,130 @@ where
     }
 
     fn wait_for_event(&self) -> Result<XEvent> {
-        todo!()
+        let numlock = ModMask::M2;
+        loop {
+            match self.conn.wait_for_event().map_err(|err| X11rbError::from(err))? {
+                Event::ButtonPress(ev) => {
+                    match to_mouse_state(ev.detail, ev.state) {
+                        Some(state) => return Ok(XEvent::MouseEvent(MouseEvent::new(ev.event, ev.root_x, ev.root_y, ev.event_x, ev.event_y, state, MouseEventKind::Press))),
+                        None => warn!("Dropping unknown mouse button event"),
+                    }
+                }
+                Event::ButtonRelease(ev) => {
+                    match to_mouse_state(ev.detail, ev.state) {
+                        Some(state) => return Ok(XEvent::MouseEvent(MouseEvent::new(ev.event, ev.root_x, ev.root_y, ev.event_x, ev.event_y, state, MouseEventKind::Release))),
+                        None => warn!("Dropping unknown mouse button event"),
+                    }
+                }
+                Event::MotionNotify(ev) => {
+                    let detail = 5; // FIXME see https://github.com/sminez/penrose/issues/113
+                    match to_mouse_state(detail, ev.state) {
+                        Some(state) => return Ok(XEvent::MouseEvent(MouseEvent::new(ev.event, ev.root_x, ev.root_y, ev.event_x, ev.event_y, state, MouseEventKind::Motion))),
+                        None => warn!("Dropping unknown mouse button event"),
+                    }
+                }
+                Event::KeyPress(ev) => {
+                    let code = KeyCode {
+                        mask: ev.state,
+                        code: ev.detail,
+                    };
+                    return Ok(XEvent::KeyPress(code.ignoring_modifier(numlock.into())));
+                }
+                Event::MapRequest(ev) => {
+                    let id = ev.window;
+                    if let Some(attr) = self.conn.get_window_attributes(id)
+                            .ok()
+                            .and_then(|cookie| cookie.reply().ok()) {
+                        return Ok(XEvent::MapRequest {
+                            id,
+                            ignore: attr.override_redirect,
+                        });
+                    }
+                }
+                Event::EnterNotify(ev) => {
+                    return Ok(XEvent::Enter {
+                        id: ev.event,
+                        rpt: Point::new(ev.root_x as u32, ev.root_y as u32),
+                        wpt: Point::new(ev.event_x as u32, ev.event_y as u32),
+                    });
+                }
+                Event::LeaveNotify(ev) => {
+                    return Ok(XEvent::Leave {
+                        id: ev.event,
+                        rpt: Point::new(ev.root_x as u32, ev.root_y as u32),
+                        wpt: Point::new(ev.event_x as u32, ev.event_y as u32),
+                    });
+                }
+                Event::DestroyNotify(ev) => return Ok(XEvent::Destroy { id: ev.window }),
+                Event::RandrScreenChangeNotify(_) => return Ok(XEvent::ScreenChange),
+                Event::ConfigureNotify(ev) => return Ok(XEvent::ConfigureNotify {
+                    id: ev.window,
+                    r: Region::new(
+                        ev.x as u32,
+                        ev.y as u32,
+                        ev.width as u32,
+                        ev.height as u32,
+                    ),
+                    is_root: ev.window == self.root,
+                }),
+                Event::ClientMessage(ev) => {
+                    if let Some(name) = self.get_atom_name(ev.type_) {
+                        let data = match ev.format {
+                            8 => ev.data.as_data8().iter().map(|&d| d as usize).collect(),
+                            16 => ev.data.as_data16().iter().map(|&d| d as usize).collect(),
+                            32 => ev.data.as_data32().iter().map(|&d| d as usize).collect(),
+                            _ => unreachable!("ClientMessageEvent.format should really be an enum..."),
+                        };
+                        return Ok(XEvent::ClientMessage {
+                            id: ev.window,
+                            dtype: name.to_string(),
+                            data,
+                        });
+                    }
+                }
+                Event::PropertyNotify(ev) => {
+                    let is_root = ev.window == self.root;
+                    if !is_root || ev.atom == self.known_atom(Atom::WmName) || ev.atom == self.known_atom(Atom::NetWmName) {
+                        if let Some(name) = self.get_atom_name(ev.atom) {
+                            return Ok(XEvent::PropertyNotify {
+                                id: ev.window,
+                                atom: name,
+                                is_root,
+                            });
+                        }
+                    }
+                }
+                // NOTE: Ignoring other event types
+                _ => {}
+            }
+        }
     }
 
     fn current_outputs(&self) -> Vec<Screen> {
-        todo!()
+        fn current_outputs_impl(conn: &impl Connection, win: WinId) -> X11Result<Vec<Screen>> {
+            let resources = conn.randr_get_screen_resources(win)?.reply()?;
+            // Send queries for all CRTCs
+            let crtcs = resources.crtcs.iter()
+                .map(|c| conn.randr_get_crtc_info(*c, 0).map_err(|err| err.into()))
+                .collect::<X11Result<Vec<_>>>()?;
+            // Get the replies and construct screens
+            let screens = crtcs.into_iter()
+                .flat_map(|cookie| cookie.reply().ok())
+                .enumerate()
+                .filter(|(_, reply)| reply.width > 0)
+                .map(|(i, reply)| {
+                    let region = Region::new(
+                        reply.x as u32,
+                        reply.y as u32,
+                        reply.width as u32,
+                        reply.height as u32,
+                    );
+                    Screen::new(region, i)
+                })
+                .collect();
+            Ok(screens)
+        }
+        current_outputs_impl(&self.conn, self.root).unwrap()
     }
 
     fn cursor_position(&self) -> Point {
@@ -154,7 +316,18 @@ where
     }
 
     fn send_client_event(&self, id: WinId, atom_name: &str) -> Result<()> {
-        todo!()
+        let atom = self.intern_atom(atom_name)?;
+        let event = ClientMessageEvent {
+            response_type: CLIENT_MESSAGE_EVENT,
+            format: 32,
+            sequence: 0,
+            window: id,
+            type_: self.known_atom(Atom::WmProtocols),
+            data: [atom, x11rb::CURRENT_TIME, 0, 0, 0].into(),
+        };
+        self.conn.send_event(false, id, EventMask::NO_EVENT, &event)
+            .map_err(|e| X11rbError::from(e).into())
+            .map(std::mem::drop)
     }
 
     fn focused_client(&self) -> WinId {
@@ -179,11 +352,71 @@ where
     }
 
     fn grab_keys(&self, key_bindings: &KeyBindings<Self>, mouse_bindings: &MouseBindings<Self>) {
-        todo!()
+        // We need to explicitly grab NumLock as an additional modifier and then drop it later on
+        // when we are passing events through to the WindowManager as NumLock alters the modifier
+        // mask when it is active.
+        let modifiers = [0, ModMask::M2.into()];
+
+        // grab keys
+        for key in key_bindings.keys() {
+            for m in modifiers.iter() {
+                self.conn.grab_key(
+                    false,           // don't pass grabbed events through to the client
+                    self.root,
+                    key.mask | m,    // modifiers to grab
+                    key.code,        // keycode to grab
+                    GrabMode::ASYNC, // don't lock the pointer input while grabbing
+                    GrabMode::ASYNC, // don't lock the keyboard input while grabbing
+                ).unwrap();
+            }
+        }
+
+        // grab mouse buttons
+        let mask = EventMask::BUTTON_PRESS | EventMask::BUTTON_RELEASE | EventMask::BUTTON_MOTION;
+        let mask = std::convert::TryInto::<u16>::try_into(u32::from(mask)).unwrap();
+        for (_, state) in mouse_bindings.keys() {
+            for m in modifiers.iter() {
+                self.conn.grab_button(
+                    false,            // don't pass grabbed events through to the client
+                    self.root,
+                    mask,             // which events are reported to the client
+                    GrabMode::ASYNC,  // don't lock the pointer input while grabbing
+                    GrabMode::ASYNC,  // don't lock the keyboard input while grabbing
+                    x11rb::NONE,      // don't confine the cursor to a specific window
+                    x11rb::NONE,      // don't change the cursor type
+                    state.button().into(), // the button to grab
+                    state.mask() | m, // modifiers to grab
+                ).unwrap();
+            }
+        }
+
+        let mask = EventMask::PROPERTY_CHANGE
+            | EventMask::SUBSTRUCTURE_REDIRECT
+            | EventMask::SUBSTRUCTURE_NOTIFY
+            | EventMask::BUTTON_MOTION;
+        let aux = ChangeWindowAttributesAux::new().event_mask(mask);
+        self.conn.change_window_attributes(self.root, &aux).unwrap();
+
+        self.conn.flush().unwrap();
     }
 
     fn set_wm_properties(&self, workspaces: &[&str]) {
-        todo!()
+        let wm_name = "penrose";
+        let check = self.known_atom(Atom::NetSupportingWmCheck);
+        for &win in [self.check_win, self.root].iter() {
+            self.conn.change_property32(PropMode::REPLACE, win, check, AtomEnum::WINDOW, &[self.check_win]).unwrap();
+            self.conn.change_property8(PropMode::REPLACE, win, AtomEnum::WM_NAME, AtomEnum::STRING, wm_name.as_bytes()).unwrap();
+        }
+
+        // EWMH support
+        let supported = EWMH_SUPPORTED_ATOMS
+            .iter()
+            .map(|a| self.known_atom(*a))
+            .collect::<Vec<u32>>();
+        let net_supported = self.known_atom(Atom::NetSupported);
+        self.conn.change_property32(PropMode::REPLACE, self.root, net_supported, AtomEnum::ATOM, &supported).unwrap();
+        self.update_desktops(workspaces);
+        self.conn.delete_property(self.root, self.known_atom(Atom::NetClientList)).unwrap();
     }
 
     fn update_desktops(&self, workspaces: &[&str]) {
@@ -212,7 +445,7 @@ where
 
     fn set_client_workspace(&self, id: WinId, wix: usize) {
         let desktop = self.known_atom(Atom::NetWmDesktop);
-        self.conn.change_property32(PropMode::REPLACE, self.root, desktop, AtomEnum::CARDINAL, &[wix as u32]).unwrap();
+        self.conn.change_property32(PropMode::REPLACE, id, desktop, AtomEnum::CARDINAL, &[wix as u32]).unwrap();
     }
 
     fn toggle_client_fullscreen(&self, id: WinId, client_is_fullscreen: bool) {
@@ -272,7 +505,16 @@ where
     }
 
     fn query_for_active_windows(&self) -> Vec<WinId> {
-        todo!()
+        match self.conn.query_tree(self.root)
+                .ok()
+                .and_then(|cookie| cookie.reply().ok()) {
+            Some(reply) => {
+                let mut children = reply.children;
+                children.retain(|&id| !self.window_has_type_in(id, &self.dont_manage_types));
+                children
+            }
+            None => Vec::new(),
+        }
     }
 
     fn str_prop(&self, id: u32, name: &str) -> Result<String> {
@@ -313,6 +555,25 @@ where
     }
 
     fn cleanup(&self) {
-        todo!()
+        // FIXME I *think* that penrose::xcb does not actually do anything here. It tries to send a
+        // couple of requests, but there is no flush() afterwards. There is a very high chance that
+        // the requests are not actually sent. Thus, this function is left empty.
     }
+}
+
+fn to_mouse_state(detail: u8, state: u16) -> Option<MouseState> {
+    fn is_held(key: &ModifierKey, mask: u16) -> bool {
+        mask & u16::from(*key) > 0
+    }
+
+    let button = match detail {
+        1 => Some(MouseButton::Left),
+        2 => Some(MouseButton::Middle),
+        3 => Some(MouseButton::Right),
+        4 => Some(MouseButton::ScrollUp),
+        5 => Some(MouseButton::ScrollDown),
+        _ => None,
+    }?;
+    let modifiers = ModifierKey::iter().filter(|m| is_held(m, state)).collect();
+    Some(MouseState { button, modifiers })
 }

--- a/src/x11rb/xconn.rs
+++ b/src/x11rb/xconn.rs
@@ -55,7 +55,7 @@ impl<C> X11rbConnection<C>
 where
     C: Connection,
 {
-    fn new_for_connection(conn: C) -> Result<Self> {
+    pub(crate) fn new_for_connection(conn: C) -> Result<Self> {
         let root = conn.setup().roots[0].root;
         conn.prefetch_extension_information(randr::X11_EXTENSION_NAME)
             .map_err(|err| X11rbError::from(err))?;

--- a/src/x11rb/xconn.rs
+++ b/src/x11rb/xconn.rs
@@ -1,4 +1,4 @@
-//! TODO: Docs
+//! API wrapper for talking to the X server using x11rb
 
 use crate::{
     PenroseError,
@@ -40,6 +40,7 @@ use std::{
     str::FromStr,
 };
 
+/// Handles communication with an X server via the x11rb crate.
 #[derive(Debug)]
 pub struct X11rbConnection<C> {
     conn: C,
@@ -54,7 +55,7 @@ impl<C> X11rbConnection<C>
 where
     C: Connection,
 {
-    pub fn new_for_connection(conn: C) -> Result<Self> {
+    fn new_for_connection(conn: C) -> Result<Self> {
         let root = conn.setup().roots[0].root;
         conn.prefetch_extension_information(randr::X11_EXTENSION_NAME)
             .map_err(|err| X11rbError::from(err))?;


### PR DESCRIPTION
This basically fixes #104 (but I already closed that issue): This adds `penrose::x11rb` with an implementation of the `XConn` trait based on x11rb.

Initially, rustfmt and clippy will surely complain loudly about this. I did not check these tools yet. I am already opening this PR so that interested people can tell me "nooo! you are doing things completely wrong!"

x11rb contains both an implementation in pure Rust (in which case it uses `#![forbid(unsafe_code)]`) and an FFI-based implementation based on libxcb. In the latter case, most of the code from libxcb is still not used, but instead things are done in Rust. This makes it possible to have a nicer API and also things should still be safe.

Right now, this code hardcodes `RustConnection` in `new_x11rb_backed_window_manager`. Perhaps it makes sense to let the caller provide its own connection with something like the following, but I am not entirely sure it makes sense to force people to call `connect()` themselves:
```rust
pub fn new_x11rb_backed_window_manager<C: x11rb::connection::Connection>(
    connection: C,
    config: Config,
    hooks: Vec<Box<dyn Hook<X11rbConnection<C>>>>,
    error_handler: ErrorHandler,
) -> crate::Result<WindowManager<X11rbConnection<C>>> {
    let conn = X11rbConnection::new_for_connection(connection)?;
    let mut wm = WindowManager::new(config, conn, hooks, error_handler);
    wm.init()?;

    Ok(wm)
}
```

While writing this code, I found two unsound APIs in xcb-rs just because the x11rb version made me handle errors that could not occur with xcb-rs (because xcb-rs was doing unsound things).

Testing done: Well... it compiles. ;-)
I also tested with the `minimal` example like this (no idea what's up with `M-grave` for me):
```diff
diff --git a/examples/minimal/main.rs b/examples/minimal/main.rs
index d6b81cf..382e636 100644
--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -12,7 +12,8 @@ use penrose::{
         bindings::MouseEvent, config::Config, helpers::index_selectors, manager::WindowManager,
     },
     logging_error_handler,
-    xcb::new_xcb_backed_window_manager,
+    //xcb::new_xcb_backed_window_manager,
+    x11rb::new_x11rb_backed_window_manager,
     Backward, Forward, Less, More, Result,
 };
 
@@ -31,8 +32,9 @@ fn main() -> Result<()> {
         "M-bracketleft" => run_internal!(cycle_screen, Backward);
         "M-S-bracketright" => run_internal!(drag_workspace, Forward);
         "M-S-bracketleft" => run_internal!(drag_workspace, Backward);
-        "M-grave" => run_internal!(cycle_layout, Forward);
-        "M-S-grave" => run_internal!(cycle_layout, Backward);
+        // thread 'main' panicked at 'invalid key binding: M-grave', examples/minimal/main.rs:24:24
+        //"M-grave" => run_internal!(cycle_layout, Forward);
+        //"M-S-grave" => run_internal!(cycle_layout, Backward);
         "M-A-Up" => run_internal!(update_max_main, More);
         "M-A-Down" => run_internal!(update_max_main, Less);
         "M-A-Right" => run_internal!(update_main_ratio, More);
@@ -52,7 +54,7 @@ fn main() -> Result<()> {
         Press Left + [Meta] => |wm: &mut WindowManager<_>, _: &MouseEvent| wm.cycle_workspace(Backward)
     };
 
-    let mut wm = new_xcb_backed_window_manager(config, hooks, logging_error_handler())?;
+    let mut wm = new_x11rb_backed_window_manager(config, hooks, logging_error_handler())?;
     wm.grab_keys_and_run(key_bindings, mouse_bindings)?;
 
     Ok(())
```
I was able to open an xterm with the above.