### PR TITLE
issue #115 checking randr version on XcbApi init

### DIFF
--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -140,7 +140,7 @@ impl Api {
         let (maj, min) = (reply.major_version(), reply.minor_version());
         if (maj, min) != (RANDR_MAJ, RANDR_MIN) {
             panic!(format!(
-                "penrose requires RandR version > {}.{}: detected {}.{}\nplease update RandR to a newer version",
+                "penrose requires RandR version >= {}.{}: detected {}.{}\nplease update RandR to a newer version",
                 RANDR_MAJ, RANDR_MIN, maj, min
             ))
         }


### PR DESCRIPTION
@psychon  are you able to take a quick look at this and see I've missed anything? This works locally for me and shows that my installed randr version is `1.6` when I push the provided version to something daft (like 999, 999).