### PR TITLE
Add XConn::init

### DIFF
--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -233,6 +233,9 @@ impl<X: XConn> WindowManager<X> {
             panic!("Need to call 'hydrate_and_init' when restoring from serialised state")
         }
 
+        debug!("Initialising XConn");
+        self.conn().init()?;
+
         debug!("Attempting initial screen detection");
         self.detect_screens()?;
 

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -293,6 +293,16 @@ pub trait XConn {
     #[cfg(feature = "serde")]
     fn hydrate(&mut self) -> Result<()>;
 
+    /// Initialise any state required before this connection can be used by the WindowManager.
+    ///
+    /// This must include checking to see if another window manager is running and return an error
+    /// if there is, but other than that there are no other requirements.
+    ///
+    /// This method is called once during [WindowManager::init][1]
+    ///
+    /// [1]: crate::core::manager::WindowManager::init
+    fn init(&self) -> Result<()>;
+
     /// Flush pending actions to the X event loop
     fn flush(&self) -> bool;
 
@@ -332,10 +342,11 @@ pub trait XConn {
     /// Change the border color for the given client
     fn set_client_border_color(&self, id: WinId, color: u32);
 
-    /// Notify the X server that we are intercepting the user specified key bindings
-    /// and prevent them being passed through to the underlying applications. This
-    /// is what determines which key press events end up being sent through in the
-    /// main event loop for the WindowManager.
+    /// Notify the X server that we are intercepting the user specified key bindings and prevent
+    /// them being passed through to the underlying applications.
+    ///
+    /// This is what determines which key press events end up being sent through in the main event
+    /// loop for the WindowManager.
     fn grab_keys(&self, key_bindings: &KeyBindings<Self>, mouse_bindings: &MouseBindings<Self>)
     where
         Self: Sized;
@@ -405,6 +416,11 @@ pub trait StubXConn {
     /// Mocked version of hydrate
     #[cfg(feature = "serde")]
     fn mock_hydrate(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Mocked version of init
+    fn mock_init(&self) -> Result<()> {
         Ok(())
     }
 
@@ -520,6 +536,10 @@ where
     #[cfg(feature = "serde")]
     fn hydrate(&mut self) -> Result<()> {
         self.mock_hydrate()
+    }
+
+    fn init(&self) -> Result<()> {
+        self.mock_init()
     }
 
     fn flush(&self) -> bool {

--- a/src/xcb/api.rs
+++ b/src/xcb/api.rs
@@ -567,9 +567,10 @@ impl XcbApi for Api {
         Ok(())
     }
 
-    fn set_window_attributes(&self, id: WinId, attrs: &[WinAttr]) {
+    fn set_window_attributes(&self, id: WinId, attrs: &[WinAttr]) -> Result<()> {
         let data: Vec<(u32, u32)> = attrs.iter().flat_map::<Vec<_>, _>(|c| c.into()).collect();
-        xcb::change_window_attributes(&self.conn, id, &data);
+        let reply = xcb::change_window_attributes_checked(&self.conn, id, &data);
+        Ok(reply.request_check()?)
     }
 
     fn unmap_window(&self, id: WinId) {

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -227,7 +227,7 @@ pub trait XcbApi {
     /// Send an event to a client
     fn send_client_event(&self, id: WinId, atom_name: &str) -> Result<()>;
     /// Set attributes on the target window
-    fn set_window_attributes(&self, id: WinId, attrs: &[WinAttr]);
+    fn set_window_attributes(&self, id: WinId, attrs: &[WinAttr]) -> Result<()>;
     /// Unmap the target window
     fn unmap_window(&self, id: WinId);
     /// Find the current size and position of the target window

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -117,6 +117,12 @@ impl XConn for XcbConnection {
         Ok(self.api.hydrate()?)
     }
 
+    fn init(&self) -> Result<()> {
+        Ok(self
+            .api
+            .set_window_attributes(self.api.root(), &[WinAttr::RootEventMask])?)
+    }
+
     fn flush(&self) -> bool {
         self.api.flush()
     }
@@ -150,7 +156,8 @@ impl XConn for XcbConnection {
 
     fn mark_new_window(&self, id: WinId) {
         let data = &[WinAttr::ClientEventMask];
-        self.api.set_window_attributes(id, data)
+        // TODO: this should return the error once XConn is updated
+        self.api.set_window_attributes(id, data).unwrap();
     }
 
     fn map_window(&self, id: WinId) {
@@ -175,7 +182,8 @@ impl XConn for XcbConnection {
 
     fn set_client_border_color(&self, id: WinId, color: u32) {
         let data = &[WinAttr::BorderColor(color)];
-        self.api.set_window_attributes(id, data);
+        // TODO: this should return the error once XConn is updated
+        self.api.set_window_attributes(id, data).unwrap();
     }
 
     fn toggle_client_fullscreen(&self, id: WinId, client_is_fullscreen: bool) {
@@ -197,8 +205,6 @@ impl XConn for XcbConnection {
                 .map(|(_, state)| state)
                 .collect::<Vec<_>>(),
         );
-        let data = &[WinAttr::RootEventMask];
-        self.api.set_window_attributes(self.api.root(), data);
         self.flush();
     }
 

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -22,7 +22,7 @@ use crate::{
             UNMANAGED_WINDOW_TYPES,
         },
     },
-    xcb::{Api, XcbApi},
+    xcb::{Api, XcbApi, XcbError},
     Result,
 };
 
@@ -120,7 +120,8 @@ impl XConn for XcbConnection {
     fn init(&self) -> Result<()> {
         Ok(self
             .api
-            .set_window_attributes(self.api.root(), &[WinAttr::RootEventMask])?)
+            .set_window_attributes(self.api.root(), &[WinAttr::RootEventMask])
+            .map_err(|e| XcbError::Raw(format!("Unable to set root window event mask: {}", e)))?)
     }
 
     fn flush(&self) -> bool {


### PR DESCRIPTION
addresses #116 by adding an `init` method to `XConn` so that any failures in setting up the connection can be surfaced to the `WindowManager`