### PR TITLE
issue #108 using Color instead of u32 for config colors

### DIFF
--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -56,8 +56,8 @@ fn main() -> Result<()> {
         // Windows with a matching WM_CLASS will always float
         .floating_classes(vec!["dmenu", "dunst", "polybar"])
         // Client border colors are set based on X focus
-        .focused_border(0xcc241d) // #cc241d
-        .unfocused_border(0x3c3836); // #3c3836
+        .focused_border("#cc241d")?
+        .unfocused_border("#3c3836")?;
 
     // When specifying a layout, most of the time you will want LayoutConf::default() as shown
     // below, which will honour gap settings and will not be run on focus changes (only when

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,5 +1,10 @@
 //! User facing configuration of the penrose [WindowManager][crate::core::manager::WindowManager].
-use crate::core::layout::{side_stack, Layout, LayoutConf};
+use crate::{
+    core::layout::{side_stack, Layout, LayoutConf},
+    draw::{Color, DrawError},
+};
+
+use std::convert::TryInto;
 
 __with_builder_and_getters! {
     /// The main user facing configuration details.
@@ -8,12 +13,13 @@ __with_builder_and_getters! {
     ///
     /// # Example
     /// ```
-    /// use penrose::Config;
+    /// use penrose::{Config, draw::Color};
+    /// use std::convert::TryFrom;
     ///
     /// let config = Config::default();
     ///
     /// assert_eq!(config.border_px(), &2);
-    /// assert_eq!(config.focused_border(), &0xcc241d);
+    /// assert_eq!(config.focused_border(), &Color::try_from("#cc241d").unwrap());
     /// ```
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[derive(Clone, Debug, PartialEq)]
@@ -45,7 +51,8 @@ __with_builder_and_getters! {
     ///     .floating_classes(vec!["rofi", "dmenu", "dunst", "pinentry-gtk-2"])
     ///     .layouts(my_layouts())
     ///     .border_px(4)
-    ///     .focused_border(0xebdbb2)
+    ///     .focused_border("#ebdbb2")
+    ///     .unwrap()
     ///     .build()
     ///     .expect("failed to build config");
     /// ```
@@ -56,15 +63,10 @@ __with_builder_and_getters! {
     ///
     /// # Constraints
     /// You must provide at least one workspace per screen
-    VecImplInto workspaces: String; =>
-        ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+    VecImplInto workspaces: String; => vec!["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
     /// the window classes that will always be considered floating
-    VecImplInto floating_classes: String; =>
-        ["dmenu", "dunst"].iter().map(|s| s.to_string()).collect();
+    VecImplInto floating_classes: String; => vec!["dmenu", "dunst"];
 
     /// the [Layout] functions to be used by each [Workspace][crate::core::workspace::Workspace]
     ///
@@ -77,9 +79,9 @@ __with_builder_and_getters! {
         ];
 
     /// the focused border color as a hex literal
-    Concrete focused_border: u32; => 0xcc241d;   // #cc241d
+    ImplTry DrawError; focused_border: Color; => "#cc241d";
     /// the unfocused border color as a hex literal
-    Concrete unfocused_border: u32; => 0x3c3836; // #3c3836
+    ImplTry DrawError; unfocused_border: Color; => "#3c3836";
     /// the border width of each window in pixels
     Concrete border_px: u32; => 2;
     /// the gap between tiled windows in pixels

--- a/src/core/xconnection.rs
+++ b/src/core/xconnection.rs
@@ -13,6 +13,7 @@ use crate::{
         data_types::{Point, Region, WinId},
         screen::Screen,
     },
+    draw::Color,
     PenroseError, Result,
 };
 
@@ -340,7 +341,7 @@ pub trait XConn {
     fn focus_client(&self, id: WinId);
 
     /// Change the border color for the given client
-    fn set_client_border_color(&self, id: WinId, color: u32);
+    fn set_client_border_color(&self, id: WinId, color: Color);
 
     /// Notify the X server that we are intercepting the user specified key bindings and prevent
     /// them being passed through to the underlying applications.
@@ -504,7 +505,7 @@ pub trait StubXConn {
     /// Mocked version of unmap_window
     fn mock_unmap_window(&self, _: WinId) {}
     /// Mocked version of set_client_border_color
-    fn mock_set_client_border_color(&self, _: WinId, _: u32) {}
+    fn mock_set_client_border_color(&self, _: WinId, _: Color) {}
     /// Mocked version of grab_keys
     fn mock_grab_keys(&self, _: &KeyBindings<Self>, _: &MouseBindings<Self>)
     where
@@ -590,7 +591,7 @@ where
         self.mock_focus_client(id)
     }
 
-    fn set_client_border_color(&self, id: WinId, color: u32) {
+    fn set_client_border_color(&self, id: WinId, color: Color) {
         self.mock_set_client_border_color(id, color)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,10 @@ pub enum PenroseError {
     #[error("UTF-8 error")]
     NonUtf8Prop(#[from] std::string::FromUtf8Error),
 
+    #[doc(hidden)]
+    #[error(transparent)]
+    Infallible(#[from] std::convert::Infallible),
+
     /// An [IO Error][std::io::Error] was encountered
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -22,6 +22,7 @@ use crate::{
             UNMANAGED_WINDOW_TYPES,
         },
     },
+    draw::Color,
     xcb::{Api, XcbApi, XcbError},
     Result,
 };
@@ -181,8 +182,8 @@ impl XConn for XcbConnection {
         self.api.mark_focused_window(id);
     }
 
-    fn set_client_border_color(&self, id: WinId, color: u32) {
-        let data = &[WinAttr::BorderColor(color)];
+    fn set_client_border_color(&self, id: WinId, color: Color) {
+        let data = &[WinAttr::BorderColor(color.rgb_u32())];
         // TODO: this should return the error once XConn is updated
         self.api.set_window_attributes(id, data).unwrap();
     }


### PR DESCRIPTION
This addresses the issue of having a common type being usable for all color based arguments in the
top level API. XCB expects a u32 in `RRGGBB` format while cairo expects f64s including alpha which
is what lead to the creation of `Color` in the first place, though it was never brought back for use
in Config.
