### PR TITLE
modifying the XConn trait to support pulling arbitrary window properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ keysyms = ["penrose_keysyms"]
 penrose_keysyms = { version = "0.1.0", path = "crates/penrose_keysyms", optional = true }
 penrose_proc = { version = "0.1.2", path = "crates/penrose_proc" }
 
+bitflags = "1.2.1"
 log = "0.4.8"
 nix = "0.17.0"
 strum = { version = "0.19.2", features = ["derive"] }

--- a/src/core/manager/event.rs
+++ b/src/core/manager/event.rs
@@ -38,8 +38,6 @@ pub enum EventAction {
     DetectScreens,
     /// A new X window needs to be mapped
     MapWindow(WinId),
-    /// A window is requesting to be moved or resized
-    MoveWindow(WinId, Region),
     /// A grabbed keybinding was triggered
     RunKeyBinding(KeyCode),
     /// A grabbed mouse state was triggered
@@ -109,7 +107,7 @@ fn process_configure_notify(id: WinId, r: Region, is_root: bool) -> Vec<EventAct
     if is_root {
         vec![EventAction::DetectScreens]
     } else {
-        vec![EventAction::MoveWindow(id, r)]
+        vec![]
     }
 }
 

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -281,7 +281,6 @@ impl<X: XConn> WindowManager<X> {
                 self.detect_screens()?
             }
             EventAction::MapWindow(id) => self.handle_map_request(id)?,
-            EventAction::MoveWindow(id, r) => self.handle_move_window(id, r)?,
             EventAction::RunKeyBinding(k) => self.run_key_binding(k, key_bindings),
             EventAction::RunMouseBinding(e) => self.run_mouse_binding(e, mouse_bindings),
             EventAction::SetActiveClient(id) => {
@@ -622,35 +621,11 @@ impl<X: XConn> WindowManager<X> {
         Ok(())
     }
 
-    fn handle_move_window(&mut self, id: WinId, r: Region) -> Result<()> {
-        info!("MOVE REQUEST: {} {:?}", id, r);
-        // if let Some(c) = self.client_map.get_mut(&id) {
-        //     if c.floating && self.conn().window_geometry(id)? != r {
-        //         self.position_client(id, r, true)?;
-        //     }
-        // }
-
-        Ok(())
-    }
-
     fn handle_prop_change(&mut self, id: WinId, atom: String, is_root: bool) -> Result<()> {
-        info!(
+        debug!(
             "GOT PROP CHANGE: id={} root={} atom={:?}",
             id, is_root, atom
         );
-        // if let Ok(a) = Atom::from_str(&atom) {
-        //     match a {
-        //         // Atom::NetActiveWindow => {
-        //         //     if !is_root
-        //         //         && self.focused_client_id() != Some(id)
-        //         //         && self.client_map.contains_key(&id)
-        //         //     {
-        //         //         self.client_gained_focus(id);
-        //         //     }
-        //         // }
-        //         _ => (),
-        //     }
-        // }
         Ok(())
     }
 

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -281,6 +281,7 @@ impl<X: XConn> WindowManager<X> {
                 self.detect_screens()?
             }
             EventAction::MapWindow(id) => self.handle_map_request(id)?,
+            EventAction::MoveWindow(id, r) => self.handle_move_window(id, r)?,
             EventAction::RunKeyBinding(k) => self.run_key_binding(k, key_bindings),
             EventAction::RunMouseBinding(e) => self.run_mouse_binding(e, mouse_bindings),
             EventAction::SetActiveClient(id) => {
@@ -621,8 +622,19 @@ impl<X: XConn> WindowManager<X> {
         Ok(())
     }
 
+    fn handle_move_window(&mut self, id: WinId, r: Region) -> Result<()> {
+        info!("MOVE REQUEST: {} {:?}", id, r);
+        // if let Some(c) = self.client_map.get_mut(&id) {
+        //     if c.floating && self.conn().window_geometry(id)? != r {
+        //         self.position_client(id, r, true)?;
+        //     }
+        // }
+
+        Ok(())
+    }
+
     fn handle_prop_change(&mut self, id: WinId, atom: String, is_root: bool) -> Result<()> {
-        debug!(
+        info!(
             "GOT PROP CHANGE: id={} root={} atom={:?}",
             id, is_root, atom
         );

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -94,11 +94,6 @@ pub(super) fn window_name<X: XConn>(conn: &X, id: WinId) -> Result<String> {
             _ => Ok(String::new()),
         },
     }
-
-    // match conn.str_prop(id, Atom::NetWmName.as_ref()) {
-    //     Ok(s) if !s.is_empty() => Ok(s),
-    //     _ => conn.str_prop(id, Atom::WmName.as_ref()),
-    // }
 }
 
 pub(super) fn get_screens<X: XConn>(

--- a/src/core/xconnection/atom.rs
+++ b/src/core/xconnection/atom.rs
@@ -1,0 +1,181 @@
+//! Data types for working with X atoms
+use strum::*;
+
+/// A Penrose internal representation of X atoms.
+///
+/// Atom names are shared between all X11 API libraries so this enum allows us to get a little bit
+/// of type safety around their use. Implementors of [XConn][1] should accept any variant of [Atom]
+/// that they are passed by client code.
+///
+/// [1]: crate::core::xconnection::XConn
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(AsRefStr, EnumString, EnumIter, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Atom {
+    /// ATOM
+    #[strum(serialize = "ATOM")]
+    Atom,
+    /// ATOM_WINDOW
+    #[strum(serialize = "ATOM_WINDOW")]
+    Window,
+    /// ATOM_CARDINAL
+    #[strum(serialize = "ATOM_CARDINAL")]
+    Cardinal,
+    /// MANAGER
+    #[strum(serialize = "MANAGER")]
+    Manager,
+    /// UTF8_STRING
+    #[strum(serialize = "UTF8_STRING")]
+    UTF8String,
+    /// WM_CLASS
+    #[strum(serialize = "WM_CLASS")]
+    WmClass,
+    /// WM_DELETE_WINDOW
+    #[strum(serialize = "WM_DELETE_WINDOW")]
+    WmDeleteWindow,
+    /// WM_PROTOCOLS
+    #[strum(serialize = "WM_PROTOCOLS")]
+    WmProtocols,
+    /// WM_STATE
+    #[strum(serialize = "WM_STATE")]
+    WmState,
+    /// WM_NAME
+    #[strum(serialize = "WM_NAME")]
+    WmName,
+    /// WM_TAKE_FOCUS
+    #[strum(serialize = "WM_TAKE_FOCUS")]
+    WmTakeFocus,
+    /// _NET_ACTIVE_WINDOW
+    #[strum(serialize = "_NET_ACTIVE_WINDOW")]
+    NetActiveWindow,
+    /// _NET_CLIENT_LIST
+    #[strum(serialize = "_NET_CLIENT_LIST")]
+    NetClientList,
+    /// _NET_CLIENT_LIST
+    #[strum(serialize = "_NET_CLIENT_LIST_STACKING")]
+    NetClientListStacking,
+    /// _NET_CURRENT_DESKTOP
+    #[strum(serialize = "_NET_CURRENT_DESKTOP")]
+    NetCurrentDesktop,
+    /// _NET_DESKTOP_NAMES
+    #[strum(serialize = "_NET_DESKTOP_NAMES")]
+    NetDesktopNames,
+    /// _NET_NUMBER_OF_DESKTOPS
+    #[strum(serialize = "_NET_NUMBER_OF_DESKTOPS")]
+    NetNumberOfDesktops,
+    /// _NET_SUPPORTED
+    #[strum(serialize = "_NET_SUPPORTED")]
+    NetSupported,
+    /// _NET_SUPPORTING_WM_CHECK
+    #[strum(serialize = "_NET_SUPPORTING_WM_CHECK")]
+    NetSupportingWmCheck,
+    /// _NET_SYSTEM_TRAY_OPCODE
+    #[strum(serialize = "_NET_SYSTEM_TRAY_OPCODE")]
+    NetSystemTrayOpcode,
+    /// _NET_SYSTEM_TRAY_ORIENTATION
+    #[strum(serialize = "_NET_SYSTEM_TRAY_ORIENTATION")]
+    NetSystemTrayOrientation,
+    /// _NET_SYSTEM_TRAY_ORIENTATION_HORZ
+    #[strum(serialize = "_NET_SYSTEM_TRAY_ORIENTATION_HORZ")]
+    NetSystemTrayOrientationHorz,
+    /// _NET_SYSTEM_TRAY_S0
+    #[strum(serialize = "_NET_SYSTEM_TRAY_S0")]
+    NetSystemTrayS0,
+    /// _NET_WM_DESKTOP
+    #[strum(serialize = "_NET_WM_DESKTOP")]
+    NetWmDesktop,
+    /// _NET_WM_NAME
+    #[strum(serialize = "_NET_WM_NAME")]
+    NetWmName,
+    /// _NET_WM_STATE
+    #[strum(serialize = "_NET_WM_STATE")]
+    NetWmState,
+    /// _NET_WM_STATE_FULLSCREEN
+    #[strum(serialize = "_NET_WM_STATE_FULLSCREEN")]
+    NetWmStateFullscreen,
+    /// _NET_WM_WINDOW_TYPE
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE")]
+    NetWmWindowType,
+    /// _XEMBED
+    #[strum(serialize = "_XEMBED")]
+    XEmbed,
+    /// _XEMBED_INFO
+    #[strum(serialize = "_XEMBED_INFO")]
+    XEmbedInfo,
+
+    // Window Types
+    /// _NET_WM_WINDOW_TYPE_DESKTOP
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_DESKTOP")]
+    NetWindowTypeDesktop,
+    /// _NET_WM_WINDOW_TYPE_DOCK
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_DOCK")]
+    NetWindowTypeDock,
+    /// _NET_WM_WINDOW_TYPE_TOOLBAR
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_TOOLBAR")]
+    NetWindowTypeToolbar,
+    /// _NET_WM_WINDOW_TYPE_MENU
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_MENU")]
+    NetWindowTypeMenu,
+    /// _NET_WM_WINDOW_TYPE_UTILITY
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_UTILITY")]
+    NetWindowTypeUtility,
+    /// _NET_WM_WINDOW_TYPE_SPLASH
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_SPLASH")]
+    NetWindowTypeSplash,
+    /// _NET_WM_WINDOW_TYPE_DIALOG
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_DIALOG")]
+    NetWindowTypeDialog,
+    /// _NET_WM_WINDOW_TYPE_DROPDOWN_MENU
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU")]
+    NetWindowTypeDropdownMenu,
+    /// _NET_WM_WINDOW_TYPE_POPUP_MENU
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_POPUP_MENU")]
+    NetWindowTypePopupMenu,
+    /// _NET_WM_WINDOW_TYPE_NOTIFICATION
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_NOTIFICATION")]
+    NetWindowTypeNotification,
+    /// _NET_WM_WINDOW_TYPE_COMBO
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_COMBO")]
+    NetWindowTypeCombo,
+    /// _NET_WM_WINDOW_TYPE_DND
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_DND")]
+    NetWindowTypeDnd,
+    /// _NET_WM_WINDOW_TYPE_NORMAL
+    #[strum(serialize = "_NET_WM_WINDOW_TYPE_NORMAL")]
+    NetWindowTypeNormal,
+}
+
+/// Clients with one of these window types will be auto floated
+pub const AUTO_FLOAT_WINDOW_TYPES: &[Atom] = &[
+    Atom::NetWindowTypeDesktop,
+    Atom::NetWindowTypeDialog,
+    Atom::NetWindowTypeDock,
+    Atom::NetWindowTypeDropdownMenu,
+    Atom::NetWindowTypeMenu,
+    Atom::NetWindowTypeNotification,
+    Atom::NetWindowTypePopupMenu,
+    Atom::NetWindowTypeSplash,
+    Atom::NetWindowTypeToolbar,
+    Atom::NetWindowTypeUtility,
+];
+
+/// Windows with a type in this array will not be managed by penrose
+pub const UNMANAGED_WINDOW_TYPES: &[Atom] = &[Atom::NetWindowTypeDock, Atom::NetWindowTypeToolbar];
+
+/// Currently supported EWMH atoms
+pub const EWMH_SUPPORTED_ATOMS: &[Atom] = &[
+    Atom::NetActiveWindow,
+    Atom::NetClientList,
+    Atom::NetClientListStacking,
+    Atom::NetCurrentDesktop,
+    Atom::NetDesktopNames,
+    Atom::NetNumberOfDesktops,
+    Atom::NetSupported,
+    Atom::NetSupportingWmCheck,
+    // Atom::NetSystemTrayS0,
+    // Atom::NetSystemTrayOpcode,
+    // Atom::NetSystemTrayOrientationHorz,
+    Atom::NetWmName,
+    Atom::NetWmState,
+    Atom::NetWmStateFullscreen,
+    Atom::NetWmWindowType,
+];

--- a/src/core/xconnection/event.rs
+++ b/src/core/xconnection/event.rs
@@ -1,0 +1,90 @@
+//! Data types for working with X events
+use crate::core::{
+    bindings::{KeyCode, MouseEvent},
+    data_types::{Point, Region, WinId},
+};
+
+/// Wrapper around the low level X event types that correspond to request / response data when
+/// communicating with the X server itself.
+///
+/// The variant names and data have developed with the reference xcb implementation in mind but
+/// should be applicable for all back ends.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub enum XEvent {
+    /// The mouse has moved or a mouse button has been pressed
+    MouseEvent(MouseEvent),
+
+    /// A grabbed key combination has been entered by the user
+    KeyPress(KeyCode),
+
+    /// A client window is requesting to be positioned and rendered on the screen
+    MapRequest {
+        /// The ID of the window that wants to be mapped
+        id: WinId,
+        /// Whether or not the WindowManager should handle this window.
+        ignore: bool,
+    },
+
+    /// The mouse pointer has entered a new client window
+    Enter {
+        /// The ID of the window that was entered
+        id: WinId,
+        /// Absolute coordinate of the event
+        rpt: Point,
+        /// Coordinate of the event relative to top-left of the window itself
+        wpt: Point,
+    },
+
+    /// The mouse pointer has left the current client window
+    Leave {
+        /// The ID of the window that was left
+        id: WinId,
+        /// Absolute coordinate of the event
+        rpt: Point,
+        /// Coordinate of the event relative to top-left of the window itself
+        wpt: Point,
+    },
+
+    /// A client window has been closed
+    Destroy {
+        /// The ID of the window being destroyed
+        id: WinId,
+    },
+
+    /// Focus has moved to a different screen
+    ScreenChange,
+
+    /// A randr action has occured (new outputs, resolution change etc)
+    RandrNotify,
+
+    /// Client config has changed in some way
+    ConfigureNotify {
+        /// The ID of the window that had a property changed
+        id: WinId,
+        /// The new window size
+        r: Region,
+        /// Is this window the root window?
+        is_root: bool,
+    },
+
+    /// A client property has changed in some way
+    PropertyNotify {
+        /// The ID of the window that had a property changed
+        id: WinId,
+        /// The property that changed
+        atom: String,
+        /// Is this window the root window?
+        is_root: bool,
+    },
+
+    /// A message has been sent to a particular client
+    ClientMessage {
+        /// The ID of the window that sent the message
+        id: WinId,
+        /// The data type being set
+        dtype: String,
+        /// The data itself
+        data: Vec<usize>,
+    },
+}

--- a/src/core/xconnection/property.rs
+++ b/src/core/xconnection/property.rs
@@ -1,0 +1,285 @@
+//! Data types for working with X window properties
+use crate::{
+    core::data_types::{Point, Region, WinId},
+    PenroseError, Result,
+};
+
+/// Know property types that should be returnable by XConn impls when they check
+/// window properties.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Prop {
+    /// One or more X Atoms
+    Atom(Vec<String>),
+    /// Raw bytes for when the prop type is non-standard
+    Bytes(Vec<u32>),
+    /// A cardinal number
+    Cardinal(u32),
+    /// UTF-8 encoded string data
+    UTF8String(Vec<String>),
+    /// An X window ID
+    Window(WinId),
+    /// The WmHints properties for this window
+    WmHints(WmHints),
+    /// The WmNormalHints properties for this window
+    WmNormalHints(WmNormalHints),
+}
+
+bitflags! {
+    /// Possible flags that can be set in a WmHints client property
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(Default)]
+    pub struct WmHintsFlags: u32 {
+        /// Input hint is set
+        const INPUT_HINT         = 0b0000000001;
+        /// State hint is set
+        const STATE_HINT         = 0b0000000010;
+        /// Icon pixmap hint is set
+        const ICON_PIXMAP_HINT   = 0b0000000100;
+        /// Icon window hint is set
+        const ICON_WINDOW_HINT   = 0b0000001000;
+        /// Icon position hint is set
+        const ICON_POSITION_HINT = 0b0000010000;
+        /// Icon mask hint is set
+        const ICON_MASK_HINT     = 0b0000100000;
+        /// Window group hint is set
+        const WINDOW_GROUP_HINT  = 0b0001000000;
+        // unused                  0b0010000000;
+        /// Urgency hint is set
+        const URGENCY_HINT       = 0b0100000000;
+    }
+}
+
+bitflags! {
+    /// Possible flags that can be set in a WmNormalHints client property
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(Default)]
+    pub struct WmNormalHintsFlags: u32 {
+        /// User-specified x, y
+        const U_POSITION    = 0b0000000001;
+        /// User-specified width, height
+        const U_SIZE        = 0b0000000010;
+        /// Program-specified position
+        const P_POSITION    = 0b0000000100;
+        /// Program-specified size
+        const P_SIZE        = 0b0000001000;
+        /// Program-specified minimum size
+        const P_MIN_SIZE    = 0b0000010000;
+        /// Program-specified maximum size
+        const P_MAX_SIZE    = 0b0000100000;
+        /// Program-specified resize increments
+        const P_RESIZE_INC  = 0b0001000000;
+        /// Program-specified min and max aspect ratios
+        const P_ASPECT      = 0b0010000000;
+        /// Program-specified base size
+        const P_BASE_SIZE   = 0b0100000000;
+        /// Program-specified window gravity
+        const P_WIN_GRAVITY = 0b1000000000;
+    }
+}
+
+/// The display states that a window can be in.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum WindowState {
+    /// Window is not visible
+    Withdrawn,
+    /// Window is visible
+    Normal,
+    /// Window is iconified
+    Iconic,
+}
+
+/// Client requested hints about information other than window geometry.
+///
+/// See the ICCCM [spec][1] for further details.
+///
+/// [1]: https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_hints_property
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct WmHints {
+    flags: WmHintsFlags,
+    accepts_input: bool,
+    initial_state: WindowState,
+    icon_pixmap: u32,
+    icon_win: WinId,
+    icon_position: Point,
+    icon_mask: u32,
+    window_group: u32,
+}
+
+impl WmHints {
+    /// Create a new instance from component parts
+    pub fn new(
+        flags: WmHintsFlags,
+        accepts_input: bool,
+        initial_state: WindowState,
+        icon_pixmap: u32,
+        icon_win: WinId,
+        icon_position: Point,
+        icon_mask: u32,
+        window_group: u32,
+    ) -> Self {
+        Self {
+            flags,
+            accepts_input,
+            initial_state,
+            icon_pixmap,
+            icon_win,
+            icon_position,
+            icon_mask,
+            window_group,
+        }
+    }
+
+    /// Try to construct a [WmHints] instance from raw bytes.
+    ///
+    /// This method expects a slice of 9 u32s corresponding to the C struct layout shown below.
+    ///
+    /// ```C
+    /// typedef struct {
+    ///     long flags;          /* marks which fields in this structure are defined */
+    ///     Bool input;          /* does this application rely on the window manager to
+    ///                             get keyboard input? */
+    ///     int initial_state;   /* see below */
+    ///     Pixmap icon_pixmap;  /* pixmap to be used as icon */
+    ///     Window icon_window;  /* window to be used as icon */
+    ///     int icon_x, icon_y;  /* initial position of icon */
+    ///     Pixmap icon_mask;    /* pixmap to be used as mask for icon_pixmap */
+    ///     XID window_group;    /* id of related window group */
+    ///     /* this structure may be extended in the future */
+    /// } XWMHints;
+    /// ```
+    pub fn try_from_bytes(raw: &[u32]) -> Result<Self> {
+        if raw.len() != 9 {
+            return Err(PenroseError::InvalidHints(format!(
+                "raw bytes should be [u32; 9] for WmHints, got [u32; {}]",
+                raw.len()
+            )));
+        }
+
+        let flags = WmHintsFlags::from_bits(raw[0]).unwrap();
+        let accepts_input = !flags.contains(WmHintsFlags::INPUT_HINT) || raw[1] > 0;
+        let initial_state = match (flags.contains(WmHintsFlags::STATE_HINT), raw[2]) {
+            (true, 0) => WindowState::Withdrawn,
+            (true, 1) | (false, _) => WindowState::Normal,
+            (true, 2) => WindowState::Iconic,
+            _ => {
+                return Err(PenroseError::InvalidHints(format!(
+                    "initial state flag should be 0, 1, 2: got {}",
+                    raw[2]
+                )))
+            }
+        };
+
+        Ok(Self {
+            flags,
+            accepts_input,
+            initial_state,
+            icon_pixmap: raw[3],
+            icon_win: raw[4],
+            icon_position: Point::new(raw[5], raw[6]),
+            icon_mask: raw[7],
+            window_group: raw[8],
+        })
+    }
+}
+
+/// Client requested hints about window geometry.
+///
+/// See the ICCCM [spec][1] for further details or the [Xlib manual][2] for more details of the
+/// data fromat but note that Penrose does not honour the following hints:
+///   - gravity
+///   - increment
+///   - aspect ratio
+///
+/// [1]: https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_normal_hints_property
+/// [2]: https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/wm-normal-hints.html
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct WmNormalHints {
+    flags: WmNormalHintsFlags,
+    base: Option<Region>,
+    min: Option<Region>,
+    max: Option<Region>,
+    user_specified: Option<Region>,
+}
+
+impl WmNormalHints {
+    /// Create a new instance from component parts
+    pub fn new(
+        flags: WmNormalHintsFlags,
+        base: Option<Region>,
+        min: Option<Region>,
+        max: Option<Region>,
+        user_specified: Option<Region>,
+    ) -> Self {
+        Self {
+            flags,
+            base,
+            min,
+            max,
+            user_specified,
+        }
+    }
+
+    /// Try to construct a [WmNormalHints] instance from raw bytes.
+    ///
+    /// This method expects a slice of 18 u32s corresponding to the C struct layout shown below.
+    ///
+    /// ```C
+    /// typedef struct {
+    ///     long flags;                /* marks which fields in this structure are defined */
+    ///     int x, y;                  /* Obsolete */
+    ///     int width, height;         /* Obsolete */
+    ///     int min_width, min_height;
+    ///     int max_width, max_height;
+    ///     int width_inc, height_inc;
+    ///     struct {
+    ///            int x;              /* numerator */
+    ///            int y;              /* denominator */
+    ///     } min_aspect, max_aspect;
+    ///     int base_width, base_height;
+    ///     int win_gravity;
+    ///     /* this structure may be extended in the future */
+    /// } XSizeHints;
+    /// ```
+    pub fn try_from_bytes(raw: &[u32]) -> Result<Self> {
+        if raw.len() != 18 {
+            return Err(PenroseError::InvalidHints(format!(
+                "raw bytes should be [u32; 18] for WmNormalHints, got [u32; {}]",
+                raw.len()
+            )));
+        }
+
+        let flags = WmNormalHintsFlags::from_bits(raw[0]).unwrap();
+
+        // These properties are marked as obsolete but some clients still set them
+        // so it they are useful as fallbacks
+        let (x, y) = (raw[1], raw[2]);
+        let (user_w, user_h) = (raw[3], raw[4]);
+
+        let (min_w, min_h) = (raw[5], raw[6]);
+        let (max_w, max_h) = (raw[7], raw[8]);
+        let (base_w, base_h) = (raw[15], raw[16]);
+
+        // ignoring increment, aspect ratio, gravity as they are not used in
+        // the main WindowManager logic
+
+        let if_set = |x, y, w, h| {
+            if w > 0 && h > 0 {
+                Some(Region::new(x, y, w, h))
+            } else {
+                None
+            }
+        };
+
+        Ok(Self {
+            flags,
+            base: if_set(x, y, base_w, base_h),
+            min: if_set(x, y, min_w, min_h),
+            max: if_set(x, y, max_w, max_h),
+            user_specified: if_set(x, y, user_w, user_h),
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@
 )]
 
 #[macro_use]
+extern crate bitflags;
+
+#[macro_use]
 extern crate log;
 
 #[cfg(feature = "serde")]
@@ -197,6 +200,10 @@ pub enum PenroseError {
     /// An [IO Error][std::io::Error] was encountered
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    /// WmNormalHints received from the X server were invalid
+    #[error("Invalid window hints property: {0}")]
+    InvalidHints(String),
 
     /// Attempting to construct a penrose data type from an int failed.
     #[error(transparent)]

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -117,6 +117,10 @@ pub enum XcbError {
     #[error("'{0}' prop is not set for client {1}")]
     MissingProp(String, WinId),
 
+    /// Property data returned for the target window was in an invalid format
+    #[error("invalid property data: {0}")]
+    InvalidPropertyData(String),
+
     /// No screens were found
     #[error("Unable to fetch setup roots from XCB")]
     NoScreens,

--- a/src/xcb/xconn.rs
+++ b/src/xcb/xconn.rs
@@ -18,7 +18,7 @@ use crate::{
         manager::WindowManager,
         screen::Screen,
         xconnection::{
-            Atom, XConn, XEvent, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS,
+            Atom, Prop, XConn, XEvent, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS,
             UNMANAGED_WINDOW_TYPES,
         },
     },
@@ -285,8 +285,8 @@ impl XConn for XcbConnection {
     }
 
     fn window_should_float(&self, id: WinId, floating_classes: &[&str]) -> bool {
-        if let Ok(s) = self.str_prop(id, Atom::WmClass.as_ref()) {
-            if s.split('\0').any(|c| floating_classes.contains(&c)) {
+        if let Ok(Prop::UTF8String(strs)) = self.get_prop(id, Atom::WmClass.as_ref()) {
+            if strs.iter().any(|c| floating_classes.contains(&c.as_ref())) {
                 return true;
             }
         }
@@ -333,12 +333,12 @@ impl XConn for XcbConnection {
         }
     }
 
-    fn str_prop(&self, id: u32, name: &str) -> Result<String> {
-        Ok(self.api.get_str_prop(id, name)?)
+    fn get_prop(&self, id: WinId, name: &str) -> Result<Prop> {
+        Ok(self.api.get_prop(id, name)?)
     }
 
-    fn atom_prop(&self, id: u32, name: &str) -> Result<u32> {
-        Ok(self.api.get_atom_prop(id, name)?)
+    fn list_props(&self, id: WinId) -> Result<Vec<String>> {
+        Ok(self.api.list_props(id)?)
     }
 
     fn intern_atom(&self, atom: &str) -> Result<u32> {


### PR DESCRIPTION
This now works:

```rust
use penrose::{xcb::Api, Result};

fn main() -> penrose::Result<()> {
    let api = Api::new()?;
    let ids = &[0x1c00002];

    for id in ids {
        for prop in api.list_props(id)?.iter() {
            match api.get_prop(id, prop) {
                Ok(val) => println!("[{}] {:?}", prop, val),
                Err(e) => println!("[{}] can't be parsed: {}", prop, e),
            }
        }
        println!();
    }
    Ok(())
}
```

### Output
```
$ cargo run --example=local_test
    Blocking waiting for file lock on build directory
   Compiling penrose v0.2.0 (/home/innes/repos/personal/penrose)
    Finished dev [unoptimized + debuginfo] target(s) in 4.05s
     Running `target/debug/examples/local_test`

[WM_HINTS] WmHints(WmHints { flags: (empty), accepts_input: true, initial_state: Normal, icon_pixmap: 0, icon_win: 0, icon_position: Point { x: 0, y: 0 }, icon_mask: 0, window_group: 0 })
[_NET_ACTIVE_WINDOW] Window(29360130)
[_NET_WM_DESKTOP] Cardinal(0)
[WM_PROTOCOLS] Atom(["WM_DELETE_WINDOW", "_NET_WM_PING"])
[_NET_WM_ICON] Cardinal(64)
[WM_NORMAL_HINTS] WmNormalHints(WmNormalHints { flags: P_SIZE, base: None, min: None, max: None, user_specified: Some(Region { x: 0, y: 0, w: 800, h: 600 }) })
[_NET_WM_WINDOW_TYPE] Atom(["_NET_WM_WINDOW_TYPE_NORMAL"])
[WM_CLIENT_MACHINE] UTF8String(["arch"])
[_NET_WM_PID] Cardinal(3037184)
[WM_CLASS] UTF8String(["Alacritty", "Alacritty"])
[XdndAware] Atom(["BITMAP"])
[_MOTIF_WM_HINTS] can't be parsed: invalid property data: prop type for _MOTIF_WM_HINTS was _MOTIF_WM_HINTS which claims to have a data format of 445
[_NET_WM_NAME] UTF8String(["innes@arch ~penrose"])
[WM_NAME] UTF8String(["innes@arch ~penrose"])
```

This, is gross:
```
[_MOTIF_WM_HINTS] can't be parsed: invalid property data: 
prop type for _MOTIF_WM_HINTS was _MOTIF_WM_HINTS which claims to have a data format of 445
```

From what I can tell, that `445` is _supposed_ to always be one of `8`, `16` or `32` in order to tell you how to parse the raw bytes...not sure where `445` is coming from but it is for non-standard prop which Penrose probably isn't going to support anyway :shrug: 