### PR TITLE
Fixed typo and incorrect link

### DIFF
--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
         allow_wrapping: false,
     };
 
-    // Defauly number of clients in the main layout area
+    // Default number of clients in the main layout area
     let n_main = 1;
 
     // Default percentage of the screen to fill with the main area of the layout

--- a/src/core/hooks.rs
+++ b/src/core/hooks.rs
@@ -186,7 +186,7 @@ pub trait Hook<X: XConn> {
     ///
     /// Inspecting newly created clients is the first and most obvious use of this hook but more
     /// advanced actions can be performed if the hook takes ownership of the client. For an
-    /// example, see the [Scratchpad][2] extension which uses this hook to capture a spawned client.
+    /// example, see the [Scratchpad][4] extension which uses this hook to capture a spawned client.
     ///
     /// [1]: crate::core::workspace::Workspace
     /// [2]: crate::core::layout::Layout


### PR DESCRIPTION
While setting up my own Penrose WM I encountered two minor errors:

 * A typo in a comment in `simple_config_with_hooks`
 * A incorrect link in documentation.

I also want to add that I really like this project and intend to use it from now on. So hopefully I can contribute a little bit more in the future.