### PR TITLE
ClientMessage: Use array instead of Vec

### DIFF
--- a/src/core/xconnection/event.rs
+++ b/src/core/xconnection/event.rs
@@ -5,6 +5,8 @@ use crate::core::{
     xconnection::{Atom, Result, XAtomQuerier, XError, Xid},
 };
 
+use std::convert::TryInto;
+
 /// Wrapper around the low level X event types that correspond to request / response data when
 /// communicating with the X server itself.
 ///
@@ -135,7 +137,7 @@ pub struct ClientMessage {
     pub mask: ClientEventMask,
     /// The data type being set
     pub dtype: String,
-    data: Vec<u32>,
+    data: [u32; 5],
 }
 
 impl ClientMessage {
@@ -151,24 +153,24 @@ impl ClientMessage {
         dtype: impl Into<String>,
         data: &[u32],
     ) -> Result<Self> {
-        if data.len() != 5 {
-            return Err(XError::InvalidClientMessageData(data.len()));
+        if let Ok(data) = data.try_into() {
+            Ok(Self::from_data_unchecked(id, mask, dtype, data))
+        } else {
+            Err(XError::InvalidClientMessageData(data.len()))
         }
-
-        Ok(Self::from_data_unchecked(id, mask, dtype, data))
     }
 
     pub(crate) fn from_data_unchecked(
         id: Xid,
         mask: ClientEventMask,
         dtype: impl Into<String>,
-        data: &[u32],
+        data: &[u32; 5],
     ) -> Self {
         Self {
             id,
             mask,
             dtype: dtype.into(),
-            data: data.to_vec(),
+            data: *data,
         }
     }
 }


### PR DESCRIPTION
This commits changes the data member of ClientMessage from type Vec<u32>
to [u32; 5]. This new type captures the necessary invariants better and
also saves an indirection (although I bet this is an unmeasurable
improvement).

All existing callers of from_data_unchecked() already used an argument
of type &[u32; 5] which was automatically coerced to &[u32]. Thus, the
API change here has no consequences (and since it is pub(crate), there
are no consequences outside of penrose).

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Something that I did not write in the commit message and which is how I came up with this change: x11rb has `impl From<[u32; 5]> for ClientMessageData` and this is "the" way to construct and instance of this type. Calling this when I only have access to `&[u32]` requires some check which I instead moved into the code in this commit / PR.