### PR TITLE
Added common XF86 keybinds

### DIFF
--- a/crates/penrose_keysyms/src/lib.rs
+++ b/crates/penrose_keysyms/src/lib.rs
@@ -1988,6 +1988,27 @@ pub enum XKeySym {
     /// XK_EuroSign
     #[strum(serialize = "EuroSign")]
     XK_EuroSign,
+    /// XF86XK_AudioLowerVolume
+    #[strum(serialize = "XF86AudioLowerVolume")]
+    XF86XK_AudioLowerVolume,
+    /// XF86XK_AudioMute
+    #[strum(serialize = "XF86AudioMute")]
+    XF86XK_AudioMute,
+    /// XF86XK_AudioRaiseVolume
+    #[strum(serialize = "XF86AudioRaiseVolume")]
+    XF86XK_AudioRaiseVolume,
+    /// XF86XK_AudioPlay
+    #[strum(serialize = "XF86AudioPlay")]
+    XF86XK_AudioPlay,
+    /// XF86XK_AudioStop
+    #[strum(serialize = "XF86AudioStop")]
+    XF86XK_AudioStop,
+    /// XF86XK_AudioPrev
+    #[strum(serialize = "XF86AudioPrev")]
+    XF86XK_AudioPrev,
+    /// XF86XK_AudioNext
+    #[strum(serialize = "XF86AudioNext")]
+    XF86XK_AudioNext,
 }
 
 impl XKeySym {
@@ -2656,6 +2677,13 @@ impl XKeySym {
                 XKeySym::XK_NewSheqelSign => 0x10020aa,
                 XKeySym::XK_DongSign => 0x10020ab,
                 XKeySym::XK_EuroSign => 0x20ac,
+                XKeySym::XF86XK_AudioLowerVolume => 0x1008FF11,
+                XKeySym::XF86XK_AudioMute => 0x1008FF12,
+                XKeySym::XF86XK_AudioRaiseVolume => 0x1008FF13,
+                XKeySym::XF86XK_AudioPlay => 0x1008FF14,
+                XKeySym::XF86XK_AudioStop => 0x1008FF15,
+                XKeySym::XF86XK_AudioPrev => 0x1008FF16,
+                XKeySym::XF86XK_AudioNext => 0x1008FF17,
             } as u32)
                 .to_le_bytes()
                 .to_vec()


### PR DESCRIPTION
This fixes #138 and is a subset of #140 .

# Test

I tested the addition on my local machine with the config (slightly edited from the `simple_config_with_hooks`

```rust
/**
 * penrose :: example configuration
 *
 * penrose does not have a traditional configuration file and is not typically set up by patching
 * the source code: it is more like Xmonad or Qtile in the sense that it is really a library for
 * writing your own window manager. Below is an example main.rs that can serve as a template should
 * you decide to write your own WM using penrose.
 */
#[macro_use]
extern crate penrose;

use penrose::{
    contrib::{
        hooks::{DefaultWorkspace, LayoutSymbolAsRootName},
        layouts::paper,
    },
    core::{
        client::Client,
        config::Config,
        helpers::index_selectors,
        hooks::Hook,
        layout::{bottom_stack, side_stack, Layout, LayoutConf},
        manager::WindowManager,
        ring::Selector,
        xconnection::XConn,
    },
    logging_error_handler,
    xcb::{XcbConnection, XcbHooks},
    Backward, Forward, Less, More, Result,
};

use simplelog::{LevelFilter, SimpleLogger};
use std::collections::HashMap;

// An example of a simple custom hook. In this case we are creating a NewClientHook which will
// be run each time a new client program is spawned.
struct MyClientHook {}
impl<X: XConn> Hook<X> for MyClientHook {
    fn new_client(&mut self, wm: &mut WindowManager<X>, c: &mut Client) -> Result<()> {
        wm.log(&format!("new client with WM_CLASS='{}'", c.wm_class()))
    }
}

fn main() -> Result<()> {
    // penrose will log useful information about the current state of the WindowManager during
    // normal operation that can be used to drive scripts and related programs. Additional debug
    // output can be helpful if you are hitting issues.
    SimpleLogger::init(LevelFilter::Debug, simplelog::Config::default())
        .expect("failed to init logging");

    // Created at startup. See keybindings below for how to access them
    let mut config_builder = Config::default().builder();
    config_builder
        .workspaces(vec!["1", "2", "3", "4", "5", "6", "7", "8", "9"])
        // Windows with a matching WM_CLASS will always float
        .floating_classes(vec!["dmenu", "dunst", "polybar"])
        // Client border colors are set based on X focus
        .focused_border("#cc241d")?
        .unfocused_border("#3c3836")?;

    // When specifying a layout, most of the time you will want LayoutConf::default() as shown
    // below, which will honour gap settings and will not be run on focus changes (only when
    // clients are added/removed). To customise when/how each layout is applied you can create a
    // LayoutConf instance with your desired properties enabled.
    let follow_focus_conf = LayoutConf {
        floating: false,
        gapless: true,
        follow_focus: true,
        allow_wrapping: false,
    };

    // Default number of clients in the main layout area
    let n_main = 1;

    // Default percentage of the screen to fill with the main area of the layout
    let ratio = 0.6;

    // Layouts to be used on each workspace. Currently all workspaces have the same set of Layouts
    // available to them, though they track modifications to n_main and ratio independently.
    config_builder.layouts(vec![
        Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
        Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
        Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
        Layout::floating("[----]"),
    ]);

    // Now build and validate the config
    let config = config_builder.build().unwrap();

    // NOTE: change these to programs that you have installed!
    let my_program_launcher = "/home/icelk/scripts/rofi/launch.sh appmenu";
    let my_file_manager = "thunar";
    let my_terminal = "alacritty";

    /* hooks
     *
     * penrose provides several hook points where you can run your own code as part of
     * WindowManager methods. This allows you to trigger custom code without having to use a key
     * binding to do so. See the hooks module in the docs for details of what hooks are avaliable
     * and when/how they will be called. Note that each class of hook will be called in the order
     * that they are defined. Hooks may maintain their own internal state which they can use to
     * modify their behaviour if desired.
     */
    let mut hooks: XcbHooks = vec![];
    hooks.push(Box::new(MyClientHook {}));

    // Using a simple contrib hook that takes no config. By convention, contrib hooks have a 'new'
    // method that returns a boxed instance of the hook with any configuration performed so that it
    // is ready to push onto the corresponding *_hooks vec.
    hooks.push(LayoutSymbolAsRootName::new());

    // Here we are using a contrib hook that requires configuration to set up a default workspace
    // on workspace "9". This will set the layout and spawn the supplied programs if we make
    // workspace "9" active while it has no clients.
    hooks.push(DefaultWorkspace::new(
        "9",
        "[botm]",
        vec![my_terminal, my_terminal, my_file_manager],
    ));

    /* The gen_keybindings macro parses user friendly key binding definitions into X keycodes and
     * modifier masks. It uses the 'xmodmap' program to determine your current keymap and create
     * the bindings dynamically on startup. If this feels a little too magical then you can
     * alternatively construct a  HashMap<KeyCode, FireAndForget> manually with your chosen
     * keybindings (see helpers.rs and data_types.rs for details).
     * FireAndForget functions do not need to make use of the mutable WindowManager reference they
     * are passed if it is not required: the run_external macro ignores the WindowManager itself
     * and instead spawns a new child process.
     */
    let key_bindings = gen_keybindings! {
        "M-XF86AudioLowerVolume" => run_external!("ponymix decrease 5%");
        "M-XF86AudioMute" => run_external!("ponymix toggle");
        "M-XF86AudioRaiseVolume" => run_external!("ponymix increase 5%");
        "M-XF86AudioPlay" => run_external!("playerctl play-pause");
        "M-XF86AudioStop" => run_external!("playerctl play-pause");
        "M-XF86AudioPrev" => run_external!("playerctl next");
        "M-XF86AudioNext" => run_external!("playerctl previous");

        // Program launch
        "M-space" => run_external!(my_program_launcher);
        "M-Return" => run_external!(my_terminal);
        "M-f" => run_external!(my_file_manager);

        // client management
        "M-j" => run_internal!(cycle_client, Forward);
        "M-k" => run_internal!(cycle_client, Backward);
        "M-S-j" => run_internal!(drag_client, Forward);
        "M-S-k" => run_internal!(drag_client, Backward);
        "M-S-q" => run_internal!(kill_client);
        "M-S-f" => run_internal!(toggle_client_fullscreen, &Selector::Focused);

        // workspace management
        "M-Tab" => run_internal!(toggle_workspace);
        "M-bracketright" => run_internal!(cycle_screen, Forward);
        "M-bracketleft" => run_internal!(cycle_screen, Backward);
        "M-S-bracketright" => run_internal!(drag_workspace, Forward);
        "M-S-bracketleft" => run_internal!(drag_workspace, Backward);

        // Layout management
        "M-A-j" => run_internal!(cycle_layout, Forward);
        "M-A-k" => run_internal!(cycle_layout, Backward);
        "M-A-Up" => run_internal!(update_max_main, More);
        "M-A-Down" => run_internal!(update_max_main, Less);
        "M-A-Right" => run_internal!(update_main_ratio, More);
        "M-A-Left" => run_internal!(update_main_ratio, Less);

        "M-A-s" => run_internal!(detect_screens);
        "M-A-Escape" => run_internal!(exit);

        // Each keybinding here will be templated in with the workspace index of each workspace,
        // allowing for common workspace actions to be bound at once.
        map: { "1", "2", "3", "4", "5", "6", "7", "8", "9" } to index_selectors(9) => {
            "M-{}" => focus_workspace (REF);
            "M-S-{}" => client_to_workspace (REF);
        };
    };

    // The underlying connection to the X server is handled as a trait: XConn. XcbConnection is the
    // reference implementation of this trait that uses the XCB library to communicate with the X
    // server. You are free to provide your own implementation if you wish, see xconnection.rs for
    // details of the required methods and expected behaviour and xcb/xconn.rs for the
    // implementation of XcbConnection.
    let conn = XcbConnection::new()?;

    // Create the WindowManager instance with the config we have built and a connection to the X
    // server. Before calling grab_keys_and_run, it is possible to run additional start-up actions
    // such as configuring initial WindowManager state, running custom code / hooks or spawning
    // external processes such as a start-up script.
    let mut wm = WindowManager::new(config, conn, hooks, logging_error_handler());
    wm.init()?;

    // NOTE: If you are using the default XCB backend provided in the penrose xcb module, then the
    //       construction of the XcbConnection and resulting WindowManager can be done using the
    //       new_xcb_backed_window_manager helper function like so:
    //
    // let mut wm = new_xcb_backed_window_manager(config)?;

    // grab_keys_and_run will start listening to events from the X server and drop into the main
    // event loop. From this point on, program control passes to the WindowManager so make sure
    // that any logic you wish to run is done before here!
    wm.grab_keys_and_run(key_bindings, HashMap::new())?;

    Ok(())
}
```

and after I sporadically pressed the media buttons got this in the log

```
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioLowerVolume' as [64, 122]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioMute' as [64, 121]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioRaiseVolume' as [64, 123]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioPlay' as [64, 215]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioStop' as [64, 174]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioPrev' as [64, 173]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-XF86AudioNext' as [64, 171]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-space' as [64, 65]
08:50:40 [DEBUG] (1) penrose::xcb::helpers: binding 'M-Return' as [64, 36]

## Other bindings removed

08:50:40 [DEBUG] (1) penrose::core::manager: Building initial workspaces
08:50:40 [DEBUG] (1) penrose::core::manager: Initialising XConn
08:50:40 [DEBUG] (1) penrose::core::manager: Attempting initial screen detection
08:50:40 [DEBUG] (1) penrose::core::manager::util: Current workspace ordering: [0, 1, 2, 3, 4, 5, 6, 7, 8]
08:50:40 [DEBUG] (1) penrose::core::manager::util: Setting focused workspace for screen Screen { wix: 0, true_region: Region { x: 3840, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 3840, y: 18, w: 1920, h: 1062 } }
08:50:40 [INFO] Detected Screen: Screen { wix: 0, true_region: Region { x: 3840, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 3840, y: 18, w: 1920, h: 1062 } }
08:50:40 [DEBUG] (1) penrose::core::manager::util: Setting focused workspace for screen Screen { wix: 1, true_region: Region { x: 1920, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 1920, y: 18, w: 1920, h: 1062 } }
08:50:40 [INFO] Detected Screen: Screen { wix: 1, true_region: Region { x: 1920, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 1920, y: 18, w: 1920, h: 1062 } }
08:50:40 [DEBUG] (1) penrose::core::manager::util: Setting focused workspace for screen Screen { wix: 2, true_region: Region { x: 0, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 0, y: 18, w: 1920, h: 1062 } }
08:50:40 [INFO] Detected Screen: Screen { wix: 2, true_region: Region { x: 0, y: 0, w: 1920, h: 1080 }, effective_region: Region { x: 0, y: 18, w: 1920, h: 1062 } }
08:50:40 [INFO] Updating known screens: 3 screens detected
08:50:40 [DEBUG] (1) penrose::core::manager: Attempting to layout workspace 0
08:50:40 [DEBUG] (1) penrose::core::manager: Running layout_applied hooks
08:50:40 [DEBUG] (1) penrose::core::manager: Attempting to layout workspace 1
08:50:40 [DEBUG] (1) penrose::core::manager: Running layout_applied hooks
08:50:40 [DEBUG] (1) penrose::core::manager: Attempting to layout workspace 2
08:50:40 [DEBUG] (1) penrose::core::manager: Running layout_applied hooks
08:50:40 [DEBUG] (1) penrose::core::manager: Running screens_updated hooks
08:50:40 [DEBUG] (1) penrose::core::manager: Setting EWMH properties
08:50:40 [DEBUG] (1) penrose::core::manager: Forcing cursor to first screen
08:50:40 [DEBUG] (1) penrose::core::manager: Registering SIGCHILD signal handler
08:50:40 [DEBUG] (1) penrose::core::manager: Grabbing key and mouse bindings
08:50:40 [DEBUG] (1) penrose::core::manager: Forcing focus to first Workspace
08:50:40 [DEBUG] (1) penrose::core::manager: Running startup hooks
08:50:40 [DEBUG] (1) penrose::core::manager: Entering main event loop

## Other XEvents (only copying relevant events)

08:50:44 [DEBUG] (1) penrose::core::manager: Got XEvent: KeyPress(KeyCode { mask: 64, code: 36 })
08:50:44 [DEBUG] (1) penrose::core::manager: Handling event action: RunKeyBinding(KeyCode { mask: 64, code: 36 })
08:50:44 [DEBUG] (1) penrose::core::manager: handling key code: KeyCode { mask: 64, code: 36 }

08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: UnknownPropertyChange(8388610, "WM_HINTS", false)
08:51:19 [DEBUG] (1) penrose::core::manager: GOT PROP CHANGE: id=8388610 root=false atom="WM_HINTS"
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:19 [DEBUG] (1) penrose::core::manager: Got XEvent: KeyPress(KeyCode { mask: 64, code: 122 })
08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: RunKeyBinding(KeyCode { mask: 64, code: 122 })
08:51:19 [DEBUG] (1) penrose::core::manager: handling key code: KeyCode { mask: 64, code: 122 }
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:19 [DEBUG] (1) penrose::core::manager: Got XEvent: PropertyNotify(PropertyEvent { id: 8388610, atom: "WM_HINTS", is_root: false })
08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: UnknownPropertyChange(8388610, "WM_HINTS", false)
08:51:19 [DEBUG] (1) penrose::core::manager: GOT PROP CHANGE: id=8388610 root=false atom="WM_HINTS"
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:19 [DEBUG] (1) penrose::core::manager: Got XEvent: KeyPress(KeyCode { mask: 64, code: 123 })
08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: RunKeyBinding(KeyCode { mask: 64, code: 123 })
08:51:19 [DEBUG] (1) penrose::core::manager: handling key code: KeyCode { mask: 64, code: 123 }
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:19 [DEBUG] (1) penrose::core::manager: Got XEvent: PropertyNotify(PropertyEvent { id: 8388610, atom: "WM_HINTS", is_root: false })
08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: UnknownPropertyChange(8388610, "WM_HINTS", false)
08:51:19 [DEBUG] (1) penrose::core::manager: GOT PROP CHANGE: id=8388610 root=false atom="WM_HINTS"
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:19 [DEBUG] (1) penrose::core::manager: Got XEvent: KeyPress(KeyCode { mask: 64, code: 123 })
08:51:19 [DEBUG] (1) penrose::core::manager: Handling event action: RunKeyBinding(KeyCode { mask: 64, code: 123 })
08:51:19 [DEBUG] (1) penrose::core::manager: handling key code: KeyCode { mask: 64, code: 123 }
08:51:19 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:20 [DEBUG] (1) penrose::core::manager: Got XEvent: PropertyNotify(PropertyEvent { id: 8388610, atom: "WM_HINTS", is_root: false })
08:51:20 [DEBUG] (1) penrose::core::manager: Handling event action: UnknownPropertyChange(8388610, "WM_HINTS", false)
08:51:20 [DEBUG] (1) penrose::core::manager: GOT PROP CHANGE: id=8388610 root=false atom="WM_HINTS"
08:51:20 [DEBUG] (1) penrose::core::manager: Running event_handled hooks
08:51:20 [DEBUG] (1) penrose::core::manager: Got XEvent: KeyPress(KeyCode { mask: 64, code: 123 })
08:51:20 [DEBUG] (1) penrose::core::manager: Handling event action: RunKeyBinding(KeyCode { mask: 64, code: 123 })
08:51:20 [DEBUG] (1) penrose::core::manager: handling key code: KeyCode { mask: 64, code: 123 }
08:51:20 [DEBUG] (1) penrose::core::manager: Running event_handled hooks

```

**I can confirm media is pausing, playing, volume lowering and rising and muting**

It all seems to work as expected.