### PR TITLE
Support arbitrary x11rb connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [ "crates/*" ]
 default = ["xcb", "xcb_draw"]
 xcb_draw = ["cairo-rs", "cairo-sys-rs", "pango", "pangocairo"]
 keysyms = ["penrose_keysyms"]
+x11rb-xcb = ["x11rb", "x11rb/allow-unsafe-code"]
 
 [dependencies]
 penrose_keysyms = { version = "0.1.0", path = "crates/penrose_keysyms", optional = true }


### PR DESCRIPTION
This commit adds a new function that allows constructing a WindowManager
from any kind of x11rb::connection::Connection. Previously, there was
only such a helper method for x11rb's RustConnection.

This also adds a new feature for enabling x11rb's XCBConnection and
providing a helper around that.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Originally I wanted to start working on `penrose::x11rb::draw`, but then quickly gave up. It would be basically the same thing as `penrose::xcb::draw`. The main difference is that instead of `self.api.conn().get_raw_conn() as *mut cairo_sys::xcb_connection_t`, one would need to get the `XCBConnection` `conn` and then do `conn.get_raw_xcb_connection() as [same cast as above]`. Well, and some other differences, the `visualtype` is a bit more complicated.

Anyway, what I really wanted to say: Copying a 264 lines files just to make some small modifications is bad. So this needs some kind of abstraction for code sharing. At this point I gave up (for now?).