### PR TITLE
implement outers gaps

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -86,6 +86,8 @@ __with_builder_and_getters! {
     Concrete border_px: u32; => 2;
     /// the gap between tiled windows in pixels
     Concrete gap_px: u32; => 5;
+    /// the gap around the whole screen, can be used to get uniform gaps
+    Concrete outer_gap_px: u32; => 0;
     /// the percentage of the screen to grow the main region by when incrementing
     Concrete main_ratio_step: f32; => 0.05;
     /// whether or not space should be reserved for a status bar

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -590,6 +590,7 @@ impl<X: XConn> WindowManager<X> {
             self.workspaces.len(),
             self.config.bar_height,
             self.config.top_bar,
+            self.config.outer_gap_px,
         )?;
 
         if screens == self.screens.as_vec() {

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -78,6 +78,7 @@ pub(super) fn get_screens<X>(
     n_workspaces: usize,
     bar_height: u32,
     top_bar: bool,
+    outer_gap: u32,
 ) -> crate::Result<Vec<Screen>>
 where
     X: XState,
@@ -96,7 +97,7 @@ where
         .zip(visible_workspaces)
         .enumerate()
         .map(|(ix, (mut s, wix))| {
-            s.update_effective_region(bar_height, top_bar);
+            s.update_effective_region(bar_height, top_bar, outer_gap);
             trace!(screen = ix, workspace = wix, "setting workspace for screen");
             s.wix = wix;
             let r = s.region(false);
@@ -270,7 +271,7 @@ mod tests {
         }
     }
 
-    fn test_screens(h: u32, top_bar: bool) -> Vec<Screen> {
+    fn test_screens(h: u32, top_bar: bool, outer_gaps: u32) -> Vec<Screen> {
         let regions = &[
             Region::new(0, 0, 1000, 800),
             Region::new(1000, 0, 1400, 900),
@@ -280,7 +281,7 @@ mod tests {
             .enumerate()
             .map(|(i, &r)| {
                 let mut s = Screen::new(r, i);
-                s.update_effective_region(h, top_bar);
+                s.update_effective_region(h, top_bar, outer_gaps);
                 s
             })
             .collect()
@@ -298,10 +299,10 @@ mod tests {
         case: more_truncates => (vec![0], 1, vec![0]);
 
         body: {
-            let (bar_height, top_bar) = (10, true);
-            let screens = test_screens(bar_height, top_bar);
+            let (bar_height, top_bar, outer_gaps) = (10, true, 10);
+            let screens = test_screens(bar_height, top_bar, outer_gaps);
             let conn = OutputsXConn(screens);
-            let new = get_screens(&conn, current, n_workspaces, bar_height, top_bar).unwrap();
+            let new = get_screens(&conn, current, n_workspaces, bar_height, top_bar, outer_gaps).unwrap();
             let focused: Vec<usize> = new.iter().map(|s| s.wix).collect();
 
             assert_eq!(focused, expected);

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -26,9 +26,19 @@ impl Screen {
     pub fn update_effective_region(&mut self, bar_height: u32, top_bar: bool, outer_gap: u32) {
         let (x, y, w, h) = self.true_region.values();
         self.effective_region = if top_bar {
-            Region::new(x + outer_gap, y + bar_height + outer_gap, w - 2*outer_gap, h - bar_height - 2*outer_gap)
+            Region::new(
+                x + outer_gap,
+                y + bar_height + outer_gap,
+                w - 2 * outer_gap,
+                h - bar_height - 2 * outer_gap,
+            )
         } else {
-            Region::new(x + outer_gap, y + outer_gap, w - 2*outer_gap, h - bar_height - 2*outer_gap)
+            Region::new(
+                x + outer_gap,
+                y + outer_gap,
+                w - 2 * outer_gap,
+                h - bar_height - 2 * outer_gap,
+            )
         }
     }
 

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -23,12 +23,12 @@ impl Screen {
 
     /// Cache the current effective region of this screen based on whether or not a bar is
     /// displayed and if that bar is positioned at the top or bottom of the screen.
-    pub fn update_effective_region(&mut self, bar_height: u32, top_bar: bool) {
+    pub fn update_effective_region(&mut self, bar_height: u32, top_bar: bool, outer_gap: u32) {
         let (x, y, w, h) = self.true_region.values();
         self.effective_region = if top_bar {
-            Region::new(x, y + bar_height, w, h - bar_height)
+            Region::new(x + outer_gap, y + bar_height + outer_gap, w - 2*outer_gap, h - bar_height - 2*outer_gap)
         } else {
-            Region::new(x, y, w, h - bar_height)
+            Region::new(x + outer_gap, y + outer_gap, w - 2*outer_gap, h - bar_height - 2*outer_gap)
         }
     }
 


### PR DESCRIPTION
Fixes #152.
Implements outer gaps.
The outer gap is a gap like around windows, but around the whole screen.
This is so you can have uniform gaps, all gaps the same size, between windows and to the screen edge. That can be achieved with outer_gap = gap.
With outer gap on 0, nothing changes from what is was before this change.
With outer gap larger than the normal gaps, you can have the in the middle type of look.