### PR TITLE
issue-143 reworking ClientData to support all 3 data formats

### DIFF
--- a/src/core/manager/event.rs
+++ b/src/core/manager/event.rs
@@ -106,11 +106,11 @@ where
 
     match Atom::from_str(&msg.dtype) {
         Ok(Atom::NetActiveWindow) => vec![EventAction::SetActiveClient(msg.id)],
-        Ok(Atom::NetCurrentDesktop) => vec![EventAction::SetActiveWorkspace(data[0] as usize)],
-        Ok(Atom::NetWmDesktop) => vec![EventAction::ClientToWorkspace(msg.id, data[0] as usize)],
-        Ok(Atom::NetWmState) if is_fullscreen(&data[1..3]) => {
+        Ok(Atom::NetCurrentDesktop) => vec![EventAction::SetActiveWorkspace(data.as_usize()[0])],
+        Ok(Atom::NetWmDesktop) => vec![EventAction::ClientToWorkspace(msg.id, data.as_usize()[0])],
+        Ok(Atom::NetWmState) if is_fullscreen(&data.as_u32()[1..3]) => {
             // _NET_WM_STATE_ADD == 1, _NET_WM_STATE_TOGGLE == 2
-            let should_fullscreen = [1, 2].contains(&data[0]);
+            let should_fullscreen = [1, 2].contains(&data.as_usize()[0]);
             vec![EventAction::ToggleClientFullScreen(
                 msg.id,
                 should_fullscreen,

--- a/src/core/xconnection/mod.rs
+++ b/src/core/xconnection/mod.rs
@@ -27,8 +27,8 @@ pub use atom::{
     Atom, AtomIter, AUTO_FLOAT_WINDOW_TYPES, EWMH_SUPPORTED_ATOMS, UNMANAGED_WINDOW_TYPES,
 };
 pub use event::{
-    ClientEventMask, ClientMessage, ClientMessageKind, ConfigureEvent, ExposeEvent, PointerChange,
-    PropertyEvent, XEvent,
+    ClientEventMask, ClientMessage, ClientMessageData, ClientMessageKind, ConfigureEvent,
+    ExposeEvent, PointerChange, PropertyEvent, XEvent,
 };
 pub use property::{
     MapState, Prop, WindowAttributes, WindowClass, WindowState, WmHints, WmNormalHints,
@@ -48,8 +48,8 @@ pub enum XError {
     ConnectionClosed,
 
     /// Client data was malformed
-    #[error("ClientMessage data must be 5 u32s: got {0}")]
-    InvalidClientMessageData(usize),
+    #[error("Invalid client message format: {0} (expected 8, 16 or 32)")]
+    InvalidClientMessageData(u8),
 
     /// The requested property is not set for the given client
     #[error("The {0} property is not set for client {1}")]

--- a/src/x11rb/xconn.rs
+++ b/src/x11rb/xconn.rs
@@ -13,9 +13,10 @@ use crate::{
         data_types::{Point, Region},
         screen::Screen,
         xconnection::{
-            Atom, ClientAttr, ClientConfig, ClientEventMask, ClientMessage, ClientMessageKind,
-            Prop, Result, WindowAttributes, WmHints, WmNormalHints, XAtomQuerier, XClientConfig,
-            XClientHandler, XClientProperties, XConn, XError, XEvent, XEventHandler, XState, Xid,
+            self, Atom, ClientAttr, ClientConfig, ClientEventMask, ClientMessage,
+            ClientMessageKind, Prop, Result, WindowAttributes, WmHints, WmNormalHints,
+            XAtomQuerier, XClientConfig, XClientHandler, XClientProperties, XConn, XError, XEvent,
+            XEventHandler, XState, Xid,
         },
     },
     x11rb::{atom::Atoms, X11rbError},
@@ -385,7 +386,11 @@ impl<C: Connection> XEventHandler for X11rbConnection<C> {
 
     fn send_client_event(&self, msg: ClientMessage) -> Result<()> {
         let type_ = self.atom_id(&msg.dtype)?;
-        let data = ClientMessageData::from(*msg.data_array());
+        let data = match msg.data() {
+            xconnection::ClientMessageData::U8(u8s) => ClientMessageData::from(*u8s),
+            xconnection::ClientMessageData::U16(u16s) => ClientMessageData::from(*u16s),
+            xconnection::ClientMessageData::U32(u32s) => ClientMessageData::from(*u32s),
+        };
         let event = ClientMessageEvent {
             response_type: CLIENT_MESSAGE_EVENT,
             format: 32,

--- a/src/xcb/mod.rs
+++ b/src/xcb/mod.rs
@@ -115,6 +115,10 @@ pub enum XcbError {
     MissingProp(String, Xid),
 
     /// Property data returned for the target window was in an invalid format
+    #[error("invalid client message data: format={0}")]
+    InvalidClientMessage(u8),
+
+    /// Property data returned for the target window was in an invalid format
     #[error("invalid property data: {0}")]
     InvalidPropertyData(String),
 


### PR DESCRIPTION
This improves the API for ClientData to support u16 and u8 messages as well as the u32 messages currently supported. This involves some re-working of existing code to use the new API but no new tests as all of the logic is handled through simple matching on enum variants.