### PR TITLE
Handle multiple keycodes for the same keysym

### DIFF
--- a/src/core/bindings.rs
+++ b/src/core/bindings.rs
@@ -23,7 +23,7 @@ pub type KeyBindings<X> = HashMap<KeyCode, KeyEventHandler<X>>;
 /// User defined mouse bindings
 pub type MouseBindings<X> = HashMap<(MouseEventKind, MouseState), MouseEventHandler<X>>;
 
-pub(crate) type CodeMap = HashMap<String, u8>;
+pub(crate) type CodeMap = HashMap<String, Vec<u8>>;
 
 /// Abstraction layer for working with key presses
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -472,13 +472,17 @@ macro_rules! __private {
                     let binding = format!($binding, name);
                     match $parse(binding.clone(), &$codes) {
                         None => panic!("invalid key binding: {}", binding),
-                        Some(key_code) => $map.insert(
-                            key_code,
-                            run_internal!(
-                                $method,
-                                __private!(@parsemapparams arg; []; $($params,)*)
-                            )
-                        ),
+                        Some(key_codes) => {
+                            for key_code in key_codes {
+                                $map.insert(
+                                    key_code,
+                                    run_internal!(
+                                        $method,
+                                        __private!(@parsemapparams arg; []; $($params,)*)
+                                    )
+                                );
+                            }
+                        }
                     };
                 }
             )+
@@ -498,7 +502,11 @@ macro_rules! __private {
     } => {
         match $parse($binding.to_string(), &$codes) {
             None => panic!("invalid key binding: {}", $binding),
-            Some(key_code) => $map.insert(key_code, $action),
+            Some(key_codes) => {
+                for key_code in key_codes {
+                    $map.insert(key_code, $action);
+                }
+            }
         };
         __private!(@parsekey $map, $codes, $parse,
             [ $binding, $($patt,)* ], [ $(($($template),+; $($name),+)),* ],

--- a/src/xcb/helpers.rs
+++ b/src/xcb/helpers.rs
@@ -18,10 +18,10 @@ use crate::core::bindings::{CodeMap, KeyCode};
  * The user friendly patterns are parsed into a modifier mask and X key code
  * pair that is then grabbed by penrose to trigger the bound action.
  */
-pub fn parse_key_binding(pattern: String, known_codes: &CodeMap) -> Option<KeyCode> {
+pub fn parse_key_binding(pattern: String, known_codes: &CodeMap) -> Option<Vec<KeyCode>> {
     let mut parts: Vec<&str> = pattern.split('-').collect();
     match known_codes.get(parts.remove(parts.len() - 1)) {
-        Some(code) => {
+        Some(codes) => {
             let mask = parts
                 .iter()
                 .map(|&s| match s {
@@ -33,11 +33,18 @@ pub fn parse_key_binding(pattern: String, known_codes: &CodeMap) -> Option<KeyCo
                 })
                 .fold(0, |acc, v| acc | v);
 
-            trace!(?pattern, mask, code, "parsed keybinding");
-            Some(KeyCode {
-                mask: mask as u16,
-                code: *code,
-            })
+            Some(
+                codes
+                    .iter()
+                    .map(|code| {
+                        trace!(?pattern, mask, code, "parsed keybinding");
+                        KeyCode {
+                            mask: mask as u16,
+                            code: *code,
+                        }
+                    })
+                    .collect(),
+            )
         }
         None => None,
     }


### PR DESCRIPTION
On my system the `Print` keysym is bound to multiple keys:

```
keycode 107 = Print Sys_Req Print Sys_Req
keycode 218 = Print NoSymbol Print
```

I've made a solution that works for my use-cases, but I am not sure if this is the right way to handle it, since it will result in a new box for each keycode.
