### PR TITLE
Permit doing keybindings without modifiers

### DIFF
--- a/crates/penrose_proc/src/validate_bindings.rs
+++ b/crates/penrose_proc/src/validate_bindings.rs
@@ -56,7 +56,7 @@ fn as_bindings(raw: Vec<String>) -> Vec<Binding> {
         .map(|s| {
             let mut parts: Vec<&str> = s.split('-').collect();
             let (keyname, mods) = if parts.len() <= 1 {
-                (None, vec![s.clone()])
+                (Some(s.clone()), vec![])
             } else {
                 (
                     parts.pop().map(String::from),
@@ -97,11 +97,10 @@ fn expand_templates(templates: Vec<String>, keynames: Vec<String>) -> Vec<Bindin
 }
 
 fn has_valid_modifiers(binding: &Binding) -> bool {
-    !binding.mods.is_empty()
-        && binding
-            .mods
-            .iter()
-            .all(|s| VALID_MODIFIERS.contains(&s.as_ref()))
+    binding
+        .mods
+        .iter()
+        .all(|s| VALID_MODIFIERS.contains(&s.as_ref()))
 }
 
 fn is_valid_keyname(binding: &Binding, names: &[String]) -> bool {
@@ -115,7 +114,7 @@ fn is_valid_keyname(binding: &Binding, names: &[String]) -> bool {
 fn report_error(msg: impl AsRef<str>, b: &Binding) {
     panic!(
         "'{}' is an invalid key binding: {}\n\
-        Key bindings should be of the form <modifiers>-<key name> e.g:  M-j, M-S-slash, M-C-Up",
+        Key bindings should be of the form <modifiers>-<key name> or <key name> e.g:  M-j, M-S-slash, M-C-Up, XF86AudioMute",
         b.raw,
         msg.as_ref()
     )

--- a/crates/penrose_proc/tests/runner.rs
+++ b/crates/penrose_proc/tests/runner.rs
@@ -15,7 +15,9 @@ fn tests() {
     t.pass("tests/validate_bindings/valid-template-bindings-are-accepted.rs");
     t.pass("tests/validate_bindings/templates-work-with-raw-bindings.rs");
     t.compile_fail("tests/validate_bindings/invalid-keys-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/invalid-keys-with-modifiers-are-rejected.rs");
     t.compile_fail("tests/validate_bindings/invalid-modifiers-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/keys-cannot-be-used-as-modifiers.rs");
     t.compile_fail("tests/validate_bindings/invalid-templates-are-rejected.rs");
     t.compile_fail("tests/validate_bindings/repeated-bindings-are-rejected.rs");
     t.compile_fail("tests/validate_bindings/bindings-clashing-with-templates-are-rejected.rs");

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.rs
@@ -2,5 +2,5 @@
 use penrose_proc::validate_user_bindings;
 
 fn main() {
-    validate_user_bindings!(("M-notarealkey")());
+    validate_user_bindings!(("notarealkey")());
 }

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.stderr
@@ -1,8 +1,8 @@
 error: proc macro panicked
  --> $DIR/invalid-keys-are-rejected.rs:5:5
   |
-5 |     validate_user_bindings!(("M-notarealkey")());
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |     validate_user_bindings!(("notarealkey")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: 'M-notarealkey' is an invalid key binding: 'notarealkey' is not a known key: run 'xmodmap -pke' to see valid key names
-          Key bindings should be of the form <modifiers>-<key name> e.g:  M-j, M-S-slash, M-C-Up
+  = help: message: 'notarealkey' is an invalid key binding: 'notarealkey' is not a known key: run 'xmodmap -pke' to see valid key names
+          Key bindings should be of the form <modifiers>-<key name> or <key name> e.g:  M-j, M-S-slash, M-C-Up, XF86AudioMute

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-with-modifiers-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-with-modifiers-are-rejected.rs
@@ -1,0 +1,6 @@
+// Bindings with invalid key names with modifiers are rejected
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("M-notarealkey")());
+}

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-with-modifiers-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-with-modifiers-are-rejected.stderr
@@ -1,0 +1,8 @@
+error: proc macro panicked
+ --> $DIR/invalid-keys-with-modifiers-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(("M-notarealkey")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'M-notarealkey' is an invalid key binding: 'notarealkey' is not a known key: run 'xmodmap -pke' to see valid key names
+          Key bindings should be of the form <modifiers>-<key name> or <key name> e.g:  M-j, M-S-slash, M-C-Up, XF86AudioMute

--- a/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.stderr
@@ -5,4 +5,4 @@ error: proc macro panicked
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: 'NOTAREALMODIFIER-a' is an invalid key binding: 'NOTAREALMODIFIER' is an invalid modifer set: valid modifiers are ["A", "M", "S", "C"]
-          Key bindings should be of the form <modifiers>-<key name> e.g:  M-j, M-S-slash, M-C-Up
+          Key bindings should be of the form <modifiers>-<key name> or <key name> e.g:  M-j, M-S-slash, M-C-Up, XF86AudioMute

--- a/crates/penrose_proc/tests/validate_bindings/keys-cannot-be-used-as-modifiers.rs
+++ b/crates/penrose_proc/tests/validate_bindings/keys-cannot-be-used-as-modifiers.rs
@@ -1,0 +1,6 @@
+// Bindings with using key names as modifiers are rejected
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("Return-a")());
+}

--- a/crates/penrose_proc/tests/validate_bindings/keys-cannot-be-used-as-modifiers.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/keys-cannot-be-used-as-modifiers.stderr
@@ -1,0 +1,8 @@
+error: proc macro panicked
+ --> $DIR/keys-cannot-be-used-as-modifiers.rs:5:5
+  |
+5 |     validate_user_bindings!(("Return-a")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'Return-a' is an invalid key binding: 'Return' is an invalid modifer set: valid modifiers are ["A", "M", "S", "C"]
+          Key bindings should be of the form <modifiers>-<key name> or <key name> e.g:  M-j, M-S-slash, M-C-Up, XF86AudioMute

--- a/crates/penrose_proc/tests/validate_bindings/templates-work-with-raw-bindings.rs
+++ b/crates/penrose_proc/tests/validate_bindings/templates-work-with-raw-bindings.rs
@@ -3,15 +3,17 @@ use penrose_proc::validate_user_bindings;
 
 fn main() {
     validate_user_bindings!((
-        "M-a",
-        "A-b",
-        "S-c",
-        "C-d",
-        "M-A-e",
-        "A-S-f",
-        "M-S-C-g",
-        "M-A-S-C-h"
+        "a",
+        "M-b",
+        "A-c",
+        "S-d",
+        "C-e",
+        "M-A-f",
+        "A-S-g",
+        "M-S-C-h",
+        "M-A-S-C-i"
     )(((
+        "{}",
         "M-{}",
         "M-S-{}",
         "M-C-{}",
@@ -19,6 +21,7 @@ fn main() {
         "M-A-C-{}",
         "M-S-C-A-{}"
     )("1", "2", "3"))((
+        "{}",
         "M-{}",
         "M-S-{}",
         "M-C-{}",

--- a/crates/penrose_proc/tests/validate_bindings/valid-bindings-are-accepted.rs
+++ b/crates/penrose_proc/tests/validate_bindings/valid-bindings-are-accepted.rs
@@ -3,13 +3,14 @@ use penrose_proc::validate_user_bindings;
 
 fn main() {
     validate_user_bindings!((
-        "M-a",
-        "A-b",
-        "S-c",
-        "C-d",
-        "M-A-e",
-        "A-S-f",
-        "M-S-C-g",
-        "M-A-S-C-h"
+        "a",
+        "M-b",
+        "A-c",
+        "S-d",
+        "C-e",
+        "M-A-f",
+        "A-S-g",
+        "M-S-C-h",
+        "M-A-S-C-i",
     )());
 }

--- a/crates/penrose_proc/tests/validate_bindings/valid-template-bindings-are-accepted.rs
+++ b/crates/penrose_proc/tests/validate_bindings/valid-template-bindings-are-accepted.rs
@@ -3,6 +3,7 @@ use penrose_proc::validate_user_bindings;
 
 fn main() {
     validate_user_bindings!(()(((
+        "{}",
         "M-{}",
         "M-S-{}",
         "M-C-{}",
@@ -10,6 +11,7 @@ fn main() {
         "M-A-C-{}",
         "M-S-C-A-{}"
     )("1", "2", "3"))((
+        "{}",
         "M-{}",
         "M-S-{}",
         "M-C-{}",

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -108,6 +108,7 @@ macro_rules! map {
 /// let key_bindings = gen_keybindings! {
 ///     "M-semicolon" => run_external!("dmenu_run");
 ///     "M-Return" => run_external!("alacritty");
+///     "XF86AudioMute" => run_external!("amixer set Master toggle");
 ///     "M-A-Escape" => run_internal!(exit);
 ///
 ///     "M-j" => run_internal!(cycle_client, Forward);


### PR DESCRIPTION
I would like to be able to add keybindings without modifiers, e.g. for volume or brightness keys on my keyboard. As far as I can tell, the runtime code has no issues with this at all, however the compile-time validator is not happy when I try.

This PR makes the compile-time validator a bit less strict, but will not change anything besides that.