### PR TITLE
Adding tests for the validate_user_bindings macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
 
     - name: Run tests
-      run: cargo test --features ${{ matrix.features }} --verbose
+      run: cargo test --workspace --features ${{ matrix.features }} --verbose
 
   rustfmt:
     name: Ensure rustfmt is happy

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check-all:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets --all-features --examples --tests
 	cargo rustdoc --all-features -- -D warnings
-	cargo test --all-features
+	cargo test --workspace --all-features
 
 .PHONY: doc
 doc:

--- a/crates/penrose_menu/src/lib.rs
+++ b/crates/penrose_menu/src/lib.rs
@@ -272,7 +272,7 @@ where
     /// # fn example<T: KeyPressDraw>(mut pmenu: PMenu<T>) -> Result<()> {
     /// let lines = vec!["foo", "bar", "baz"];
     ///
-    /// match pmenu.get_selection_from_input(">>> ", lines, 0)? {
+    /// match pmenu.get_selection_from_input(Some(">>> "), lines, 0)? {
     ///     PMenuMatch::Line(i, s) => println!("matched {} on line {}", s, i),
     ///     PMenuMatch::UserInput(s) => println!("user input: {}", s),
     ///     PMenuMatch::NoMatch => println!("no match"),

--- a/crates/penrose_menu/src/lib.rs
+++ b/crates/penrose_menu/src/lib.rs
@@ -122,17 +122,6 @@ where
     D: KeyPressDraw,
 {
     /// Construct a new [PMenu] with the given config.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use penrose::xcb::XcbDraw;
-    /// use penrose_menu::{PMenu, PMenuConfig};
-    ///
-    /// let mut pmenu = match XcbDraw::new() {
-    ///     Ok(drw) => PMenu::new(drw, PMenuConfig::default()),
-    ///     Err(e) => panic!("unable to initialise Draw: {}", e),
-    /// };
-    /// ```
     pub fn new(mut drw: D, config: PMenuConfig) -> Result<Self> {
         if !(0.0..=1.0).contains(&config.min_width_perc) {
             return Err(DrawError::Raw(format!(

--- a/crates/penrose_proc/src/lib.rs
+++ b/crates/penrose_proc/src/lib.rs
@@ -1,7 +1,8 @@
 //! Proc macros for use in the main Penrose crate
 #![warn(
-    broken_intra_doc_links,
-    clippy::all,
+    clippy::complexity,
+    clippy::correctness,
+    clippy::style,
     future_incompatible,
     missing_debug_implementations,
     missing_docs,

--- a/crates/penrose_proc/tests/runner.rs
+++ b/crates/penrose_proc/tests/runner.rs
@@ -11,4 +11,12 @@ fn tests() {
     t.pass("tests/stub/visibility-is-correct.rs");
     t.compile_fail("tests/stub/visibility-is-correct-failure.rs");
     t.compile_fail("tests/stub/test-only-attr-works.rs");
+    t.pass("tests/validate_bindings/valid-bindings-are-accepted.rs");
+    t.pass("tests/validate_bindings/valid-template-bindings-are-accepted.rs");
+    t.pass("tests/validate_bindings/templates-work-with-raw-bindings.rs");
+    t.compile_fail("tests/validate_bindings/invalid-keys-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/invalid-modifiers-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/invalid-templates-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/repeated-bindings-are-rejected.rs");
+    t.compile_fail("tests/validate_bindings/bindings-clashing-with-templates-are-rejected.rs");
 }

--- a/crates/penrose_proc/tests/validate_bindings/bindings-clashing-with-templates-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/bindings-clashing-with-templates-are-rejected.rs
@@ -1,0 +1,6 @@
+// Bindings that use valid modifiers and valid keys are accepted
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("M-a")((("M-{}")("a"))));
+}

--- a/crates/penrose_proc/tests/validate_bindings/bindings-clashing-with-templates-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/bindings-clashing-with-templates-are-rejected.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> $DIR/bindings-clashing-with-templates-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(("M-a")((("M-{}")("a"))));
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'M-a' is bound as a keybinding more than once

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.rs
@@ -1,0 +1,6 @@
+// Bindings with invalid key names are rejected
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("M-notarealkey")());
+}

--- a/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-keys-are-rejected.stderr
@@ -1,0 +1,8 @@
+error: proc macro panicked
+ --> $DIR/invalid-keys-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(("M-notarealkey")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'M-notarealkey' is an invalid key binding: 'notarealkey' is not a known key: run 'xmodmap -pke' to see valid key names
+          Key bindings should be of the form <modifiers>-<key name> e.g:  M-j, M-S-slash, M-C-Up

--- a/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.rs
@@ -1,0 +1,6 @@
+// Bindings with invalid modifier names are rejected
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("NOTAREALMODIFIER-a")());
+}

--- a/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-modifiers-are-rejected.stderr
@@ -1,0 +1,8 @@
+error: proc macro panicked
+ --> $DIR/invalid-modifiers-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(("NOTAREALMODIFIER-a")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'NOTAREALMODIFIER-a' is an invalid key binding: 'NOTAREALMODIFIER' is an invalid modifer set: valid modifiers are ["A", "M", "S", "C"]
+          Key bindings should be of the form <modifiers>-<key name> e.g:  M-j, M-S-slash, M-C-Up

--- a/crates/penrose_proc/tests/validate_bindings/invalid-templates-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-templates-are-rejected.rs
@@ -1,0 +1,6 @@
+// Bindings that use valid modifiers and valid keys in templates are accepted
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(()((("Not a template")("1", "2", "3"))));
+}

--- a/crates/penrose_proc/tests/validate_bindings/invalid-templates-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/invalid-templates-are-rejected.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> $DIR/invalid-templates-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(()((("Not a template")("1", "2", "3"))));
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'Not a template' is an invalid template: expected '<Modifiers>-{}'

--- a/crates/penrose_proc/tests/validate_bindings/repeated-bindings-are-rejected.rs
+++ b/crates/penrose_proc/tests/validate_bindings/repeated-bindings-are-rejected.rs
@@ -1,0 +1,6 @@
+// Repeated raw bindings are rejected
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(("M-a", "M-a")());
+}

--- a/crates/penrose_proc/tests/validate_bindings/repeated-bindings-are-rejected.stderr
+++ b/crates/penrose_proc/tests/validate_bindings/repeated-bindings-are-rejected.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> $DIR/repeated-bindings-are-rejected.rs:5:5
+  |
+5 |     validate_user_bindings!(("M-a", "M-a")());
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: 'M-a' is bound as a keybinding more than once

--- a/crates/penrose_proc/tests/validate_bindings/templates-work-with-raw-bindings.rs
+++ b/crates/penrose_proc/tests/validate_bindings/templates-work-with-raw-bindings.rs
@@ -1,0 +1,29 @@
+// Bindings that use valid modifiers and valid keys in templates are accepted
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!((
+        "M-a",
+        "A-b",
+        "S-c",
+        "C-d",
+        "M-A-e",
+        "A-S-f",
+        "M-S-C-g",
+        "M-A-S-C-h"
+    )(((
+        "M-{}",
+        "M-S-{}",
+        "M-C-{}",
+        "M-S-C-{}",
+        "M-A-C-{}",
+        "M-S-C-A-{}"
+    )("1", "2", "3"))((
+        "M-{}",
+        "M-S-{}",
+        "M-C-{}",
+        "M-S-C-{}",
+        "M-A-C-{}",
+        "M-S-C-A-{}"
+    )("Return", "Tab"))));
+}

--- a/crates/penrose_proc/tests/validate_bindings/valid-bindings-are-accepted.rs
+++ b/crates/penrose_proc/tests/validate_bindings/valid-bindings-are-accepted.rs
@@ -1,0 +1,15 @@
+// Bindings that use valid modifiers and valid keys are accepted
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!((
+        "M-a",
+        "A-b",
+        "S-c",
+        "C-d",
+        "M-A-e",
+        "A-S-f",
+        "M-S-C-g",
+        "M-A-S-C-h"
+    )());
+}

--- a/crates/penrose_proc/tests/validate_bindings/valid-template-bindings-are-accepted.rs
+++ b/crates/penrose_proc/tests/validate_bindings/valid-template-bindings-are-accepted.rs
@@ -1,0 +1,20 @@
+// Bindings that use valid modifiers and valid keys in templates are accepted
+use penrose_proc::validate_user_bindings;
+
+fn main() {
+    validate_user_bindings!(()(((
+        "M-{}",
+        "M-S-{}",
+        "M-C-{}",
+        "M-S-C-{}",
+        "M-A-C-{}",
+        "M-S-C-A-{}"
+    )("1", "2", "3"))((
+        "M-{}",
+        "M-S-{}",
+        "M-C-{}",
+        "M-S-C-{}",
+        "M-A-C-{}",
+        "M-S-C-A-{}"
+    )("Return", "Tab"))));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,6 @@
 //! [14]: https://xcb.freedesktop.org/
 //! [15]: https://www.rust-lang.org
 #![warn(
-    broken_intra_doc_links,
     clippy::complexity,
     clippy::correctness,
     clippy::style,


### PR DESCRIPTION
This also makes sure that all test suites in the workspace are run in CI and under 'make check-all' locally. There was an issue with one of the doc-tests in penrose_menu which has been addressed as part of this as well as it would cause the tests to fail othewise.