### PR TITLE
Dwindle layout

### DIFF
--- a/src/contrib/layouts.rs
+++ b/src/contrib/layouts.rs
@@ -51,3 +51,40 @@ pub fn paper(
         })
         .collect()
 }
+
+fn dwindle_recurisive(clients: &[&Client], region: &Region, horizontal: bool) -> Vec<ResizeAction> {
+    if clients.len() > 1 {
+        let split = ((if horizontal { region.w } else { region.h } as f32) / 2.) as u32;
+        let (main, other) = if horizontal {
+            region.split_at_width(split)
+        } else {
+            region.split_at_height(split)
+        }
+        .unwrap();
+
+        let mut vec = dwindle_recurisive(&clients[..clients.len() - 1], &other, !horizontal);
+        vec.push((clients.last().unwrap().id(), Some(main)));
+        vec
+    } else {
+        clients
+            .get(0)
+            .map(|c| vec![(c.id(), Some(*region))])
+            .unwrap_or(Vec::new())
+    }
+}
+
+/**
+ * A layout based on the dwindle layout from AwesomeWM.
+ *
+ * The second region is recursively split in two other regions, alternating between
+ * splitting horizontally and vertically.
+ */
+pub fn dwindle(
+    clients: &[&Client],
+    _: Option<Xid>,
+    monitor_region: &Region,
+    _: u32,
+    _: f32,
+) -> Vec<ResizeAction> {
+    dwindle_recurisive(clients, monitor_region, true)
+}


### PR DESCRIPTION
I've made a layout based on the "dwindle" layout from AwesomeWM and dwm (see https://awesomewm.org/doc/api/libraries/awful.layout.html#awful.layout.suit.spiral.dwindle and https://dwm.suckless.org/patches/fibonacci/). Here's an image of how it looks:

![Screenshot_20210714_132512](https://user-images.githubusercontent.com/7491613/125614467-8178958f-77c3-4fc6-b767-a55771d108fd.png)

I did notice a problem when creating too many windows with this layout. When a `Region` becomes too small, the following subtraction causes a panic: https://github.com/sminez/penrose/blob/6b3ea78a6b34d0c49bc239d7f9308f85a2135569/src/core/manager/util.rs#L19 

I was not able to reproduce this on other layouts yet.