### PR TITLE
Fix underflow

### DIFF
--- a/src/__test_helpers.rs
+++ b/src/__test_helpers.rs
@@ -121,6 +121,7 @@ pub struct TestXConn {
     focused: Cell<Xid>,
     n_screens: Cell<u32>,
     unmanaged_ids: Vec<Xid>,
+    client_geometry: Cell<Region>,
 }
 
 impl fmt::Debug for TestXConn {
@@ -142,6 +143,7 @@ impl TestXConn {
             focused: Cell::new(0),
             n_screens: Cell::new(n_screens),
             unmanaged_ids,
+            client_geometry: Cell::new(Region::default()),
         }
     }
 
@@ -171,7 +173,12 @@ __impl_stub_xcon! {
             Ok(())
         }
     }
-    client_config: {}
+    client_config: {
+        fn mock_position_client(&self, _id: Xid, r: Region, _border: u32, _stack_above: bool) -> Result<()> {
+            self.client_geometry.set(r);
+            Ok(())
+        }
+    }
     event_handler: {
         fn mock_wait_for_event(&self) -> Result<XEvent> {
             let mut remaining = self.events.replace(vec![]);
@@ -193,6 +200,10 @@ __impl_stub_xcon! {
 
         fn mock_focused_client(&self) -> Result<Xid> {
             Ok(self.focused.get())
+        }
+
+        fn mock_client_geometry(&self, id: Xid) -> Result<Region> {
+            Ok(self.client_geometry.get())
         }
     }
     conn: {

--- a/src/__test_helpers.rs
+++ b/src/__test_helpers.rs
@@ -202,7 +202,7 @@ __impl_stub_xcon! {
             Ok(self.focused.get())
         }
 
-        fn mock_client_geometry(&self, id: Xid) -> Result<Region> {
+        fn mock_client_geometry(&self, _id: Xid) -> Result<Region> {
             Ok(self.client_geometry.get())
         }
     }

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -105,6 +105,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::__test_helpers::*;
 
     #[test]
     fn pad_region_centered() {
@@ -122,5 +123,33 @@ mod tests {
         let b = 3;
         assert_eq!(pad_region(&r, false, g, b), r);
         assert_eq!(pad_region(&r, true, g, b), r);
+    }
+
+    #[test]
+    fn position_floating() {
+        let conn = TestXConn::new(1, vec![], vec![]);
+        conn.position_client(0, Region::new(0, 0, 400, 300), 2, false)
+            .unwrap();
+
+        position_floating_client(&conn, 0, Region::default(), 2).unwrap();
+
+        assert_eq!(
+            conn.client_geometry(0).unwrap(),
+            Region::new(2, 2, 396, 296)
+        );
+    }
+
+    #[test]
+    fn position_floating_tiny() {
+        let conn = TestXConn::new(1, vec![], vec![]);
+        conn.position_client(0, Region::new(0, 0, 4, 3), 2, false)
+            .unwrap();
+
+        position_floating_client(&conn, 0, Region::default(), 2).unwrap();
+
+        assert_eq!(
+            conn.client_geometry(0).unwrap(),
+            Region::new(0, 0, 4, 3)
+        );
     }
 }

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -114,4 +114,13 @@ mod tests {
         assert_eq!(pad_region(&r, false, g, b), Region::new(10, 10, 174, 74));
         assert_eq!(pad_region(&r, true, g, b), Region::new(0, 0, 194, 94));
     }
+
+    #[test]
+    fn pad_region_tiny() {
+        let r = Region::new(0, 0, 3, 3);
+        let g = 10;
+        let b = 3;
+        assert_eq!(pad_region(&r, false, g, b), r);
+        assert_eq!(pad_region(&r, true, g, b), r);
+    }
 }

--- a/src/core/manager/util.rs
+++ b/src/core/manager/util.rs
@@ -20,6 +20,7 @@ pub(super) fn pad_region(region: &Region, gapless: bool, gap_px: u32, border_px:
     // Check that the resulting size would not be zero or negative
     // Do not allow zero-size as this is chosen by the WM
     if w <= padding || h <= padding {
+        warn!("not padding region to avoid integer underflow");
         return *region;
     }
 
@@ -51,6 +52,7 @@ where
             h - (2 * border_px),
         )
     } else {
+        warn!("floating client too small {}", id);
         Region::new(x, y, w, h)
     };
 


### PR DESCRIPTION
There are two places in `src/core/manager/util.rs` where an integer underflow can occur when applying padding. This PR checks for when this will occur and, instead of panicking, logs a warning and continues the operation as if the padding were not applied.

I think that this fixes #179 and https://github.com/sminez/penrose/pull/180#issuecomment-879863732. Another way to trigger the underflow described in #180 is to adjust the main ratio to either extreme.