### PR TITLE
Fix fullscreen

### DIFF
--- a/src/__test_helpers.rs
+++ b/src/__test_helpers.rs
@@ -66,7 +66,18 @@ pub fn test_screens(n: u32) -> Vec<Screen> {
 pub fn test_layouts() -> Vec<Layout> {
     vec![
         Layout::new("first", LayoutConf::default(), row_layout, 1, 0.6),
-        Layout::new("second", LayoutConf::default(), row_layout, 1, 0.6),
+        Layout::new(
+            "second",
+            LayoutConf {
+                allow_wrapping: true,
+                floating: true,
+                follow_focus: false,
+                gapless: false,
+            },
+            row_layout,
+            1,
+            0.6,
+        ),
     ]
 }
 

--- a/src/core/manager/clients.rs
+++ b/src/core/manager/clients.rs
@@ -390,12 +390,13 @@ mod tests {
             n_clients: u32,
             fullscreen: Option<Xid>,
             target: Xid,
+            expect_fullscreen: bool,
         );
 
-        case: single_client_on => (1, None, 0);
-        case: single_client_off => (1, Some(0), 0);
-        case: multiple_clients_on => (4, None, 1);
-        case: multiple_clients_off => (4, Some(1), 1);
+        case: single_client_on => (1, None, 0, true);
+        case: single_client_off => (1, Some(0), 0, false);
+        case: multiple_clients_on => (4, None, 1, true);
+        case: multiple_clients_off => (4, Some(1), 1, false);
 
         body: {
             let conn = RecordingXConn::init();
@@ -421,6 +422,7 @@ mod tests {
             let events = clients.toggle_fullscreen(target, 42, &conn).unwrap();
 
             assert_eq!(events.len(), 1);
+            assert_eq!(clients.get(target).map(|c| c.fullscreen), Some(expect_fullscreen));
         }
     }
 }

--- a/src/core/manager/clients.rs
+++ b/src/core/manager/clients.rs
@@ -262,6 +262,7 @@ impl Clients {
         &mut self,
         actions: ArrangeActions,
         lc: &LayoutConf,
+        borderless: bool,
         border_px: u32,
         gap_px: u32,
         conn: &X,
@@ -269,12 +270,14 @@ impl Clients {
     where
         X: XClientHandler + XClientConfig,
     {
+        let bpx = if borderless { 0 } else { border_px };
+
         // Tile first then place floating clients on top
         for (id, region) in actions.actions {
             trace!(id, ?region, "positioning client");
             if let Some(region) = region {
-                let reg = pad_region(&region, lc.gapless, gap_px, border_px);
-                conn.position_client(id, reg, border_px, false)?;
+                let reg = pad_region(&region, lc.gapless, gap_px, bpx);
+                conn.position_client(id, reg, bpx, false)?;
                 self.map_if_needed(id, conn)?;
             } else {
                 self.unmap_if_needed(id, conn)?;

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -702,12 +702,7 @@ impl<X: XConn> WindowManager<X> {
         if clients.iter().any(|c| c.fullscreen) {
             let region = s.region(false);
             // TODO: Default may be enough
-            let lc = LayoutConf {
-                floating: false,
-                gapless: true,
-                follow_focus: false,
-                allow_wrapping: false,
-            };
+            let lc = LayoutConf::default();
             let arrange_actions = ArrangeActions {
                 actions: clients
                     .iter()

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -668,7 +668,6 @@ impl<X: XConn> WindowManager<X> {
 
     // Toggle the given client fullscreen. This has knock on effects for other windows and can
     // be triggered by user key bindings as well as applications requesting full screen as well.
-    // TODO: should something going fullscreen also hide unmaged windows?
     fn set_fullscreen(&mut self, id: Xid, should_fullscreen: bool) -> Result<()> {
         let (currently_fullscreen, wix) = self
             .clients

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -702,11 +702,11 @@ impl<X: XConn> WindowManager<X> {
         let (lc, borderless, arrange_actions) =
             self.workspaces
                 .get_arrange_actions(wix, region, fullscreen_region, &clients)?;
-        let border_px = if borderless { 0 } else { self.config.border_px };
         self.clients.apply_arrange_actions(
             arrange_actions,
             &lc,
-            border_px,
+            borderless,
+            self.config.border_px,
             self.config.gap_px,
             &self.conn,
         )?;

--- a/src/core/manager/workspaces.rs
+++ b/src/core/manager/workspaces.rs
@@ -238,13 +238,6 @@ impl Workspaces {
         }
     }
 
-    pub fn client_ids(&self, wix: usize) -> Result<Vec<Xid>> {
-        self.inner
-            .get(wix)
-            .map(|ws| ws.client_ids())
-            .ok_or_else(|| perror!("unknown workspace: {}", wix))
-    }
-
     pub fn focused_client(&self, ix: usize) -> Option<Xid> {
         self.inner[ix].focused_client()
     }

--- a/src/core/manager/workspaces.rs
+++ b/src/core/manager/workspaces.rs
@@ -380,177 +380,124 @@ mod tests {
         }
     }
 
-    #[test]
-    fn arrange_none() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 0)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![]);
-
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![],
-            )
-            .unwrap();
-
-        assert_eq!(lc, wss[0].layout_conf());
-        assert!(!borderless);
-        assert_eq!(actions.actions, vec![]);
-        assert_eq!(actions.floating, vec![]);
-    }
-
-    #[test]
-    fn arrange_single() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 1)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![0]);
-
-        let client_0 = test_client(0, false, false);
-
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![&client_0],
-            )
-            .unwrap();
-
-        assert_eq!(lc, wss[0].layout_conf());
-        assert!(!borderless);
-        assert_eq!(
-            actions.actions,
-            vec![(0, Some(Region::new(0, 20, 800, 580)))]
+    test_cases! {
+        arrange;
+        args: (
+            floating_layout: bool,
+            clients: Vec<Client>,
+            expected_gapless: bool,
+            expected_borderless: bool,
+            expected_actions: Vec<ResizeAction>,
+            expected_floating: Vec<Xid>,
         );
-        assert_eq!(actions.floating, vec![]);
-    }
 
-    #[test]
-    fn arrange_multiple() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 4)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![0, 1, 2, 3]);
+        case: none => (
+            false, vec![],
+            false, false,
+            vec![], vec![]
+        );
 
-        let client_0 = test_client(0, false, false);
-        let client_1 = test_client(1, false, false);
-        let client_2 = test_client(2, false, false);
-        let client_3 = test_client(3, false, false);
+        case: single => (
+            false,
+            vec![
+                test_client(0, false, false),
+            ],
+            false, false,
+            vec![
+                (0, Some(Region::new(0, 20, 800, 580))),
+            ],
+            vec![]
+        );
 
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![&client_0, &client_1, &client_2, &client_3],
-            )
-            .unwrap();
-
-        assert_eq!(lc, LayoutConf::default());
-        assert!(!borderless);
-        assert_eq!(
-            actions.actions,
+        case: multiple => (
+            false,
+            vec![
+                test_client(0, false, false),
+                test_client(1, false, false),
+                test_client(2, false, false),
+                test_client(3, false, false),
+            ],
+            false, false,
             vec![
                 (0, Some(Region::new(0, 20, 800, 145))),
                 (1, Some(Region::new(0, 165, 800, 145))),
                 (2, Some(Region::new(0, 310, 800, 145))),
                 (3, Some(Region::new(0, 455, 800, 145))),
-            ]
+            ],
+            vec![]
         );
-        assert_eq!(actions.floating, vec![]);
-    }
 
-    #[test]
-    fn arrange_fullscreen() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 4)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![0, 1, 2, 3]);
-
-        let client_0 = test_client(0, false, false);
-        let client_1 = test_client(1, false, true);
-        let client_2 = test_client(2, true, false);
-        let client_3 = test_client(3, false, false);
-
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![&client_0, &client_1, &client_2, &client_3],
-            )
-            .unwrap();
-
-        assert_eq!(
-            lc,
-            LayoutConf {
-                gapless: true,
-                ..wss[0].layout_conf()
-            }
-        );
-        assert!(borderless);
-        assert_eq!(
-            actions.actions,
+        case: fullscreen => (
+            false,
+            vec![
+                test_client(0, false, false),
+                test_client(1, false, false),
+                test_client(2, false, true),
+                test_client(3, false, false),
+            ],
+            true, true,
             vec![
                 (0, None),
-                (1, Some(Region::new(0, 0, 800, 600))),
-                (2, None),
+                (1, None),
+                (2, Some(Region::new(0, 0, 800, 600))),
                 (3, None),
-            ]
+            ],
+            vec![]
         );
-        assert_eq!(actions.floating, vec![]);
-    }
 
-    #[test]
-    fn arrange_some_floating() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 4)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![0, 1, 2, 3]);
-
-        let client_0 = test_client(0, false, false);
-        let client_1 = test_client(1, true, false);
-        let client_2 = test_client(2, true, false);
-        let client_3 = test_client(3, false, false);
-
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![&client_0, &client_1, &client_2, &client_3],
-            )
-            .unwrap();
-
-        assert_eq!(lc, wss[0].layout_conf());
-        assert!(!borderless);
-        assert_eq!(
-            actions.actions,
+        case: some_floating => (
+            false,
+            vec![
+                test_client(0, false, false),
+                test_client(1, true, false),
+                test_client(2, true, false),
+                test_client(3, false, false),
+            ],
+            false, false,
             vec![
                 (0, Some(Region::new(0, 20, 800, 290))),
                 (3, Some(Region::new(0, 310, 800, 290))),
-            ]
+            ],
+            vec![1, 2]
         );
-        assert_eq!(actions.floating, vec![1, 2]);
-    }
 
-    #[test]
-    fn arrange_all_floating() {
-        let mut wss = Workspaces::new(vec![test_workspace("test", 4)], 0.1);
-        assert_eq!(wss[0].client_ids(), vec![0, 1, 2, 3]);
-        wss[0].cycle_layout(Forward); // Switch to the floating test layout
+        case: all_floating => (
+            true,
+            vec![
+                test_client(0, false, false),
+                test_client(1, true, false),
+                test_client(2, true, false),
+                test_client(3, false, false),
+            ],
+            false, false,
+            vec![],
+            vec![0, 1, 2, 3]
+        );
 
-        let client_0 = test_client(0, false, false);
-        let client_1 = test_client(1, true, false);
-        let client_2 = test_client(2, false, false);
-        let client_3 = test_client(3, true, false);
+        body: {
+            let mut wss = Workspaces::new(vec![test_workspace("test", clients.len() as u32)], 0.1);
 
-        let (lc, borderless, actions) = wss
-            .get_arrange_actions(
-                0,
-                Region::new(0, 20, 800, 580),
-                Region::new(0, 0, 800, 600),
-                &vec![&client_0, &client_1, &client_2, &client_3],
-            )
-            .unwrap();
+            if floating_layout {
+                wss[0].cycle_layout(Forward);
+            }
 
-        assert_eq!(lc, wss[0].layout_conf());
-        assert!(!borderless);
-        assert_eq!(actions.actions, vec![]);
-        assert_eq!(actions.floating, vec![0, 1, 2, 3]);
+            let (lc, borderless, actions) = wss
+                .get_arrange_actions(
+                    0,
+                    Region::new(0, 20, 800, 580),
+                    Region::new(0, 0, 800, 600),
+                    &clients.iter().collect::<Vec<&Client>>(),
+                )
+                .unwrap();
+
+            if expected_gapless {
+                assert_eq!(lc, LayoutConf { gapless: true, ..wss[0].layout_conf() });
+            } else {
+                assert_eq!(lc, wss[0].layout_conf());
+            }
+            assert_eq!(borderless, expected_borderless);
+            assert_eq!(actions.actions, expected_actions);
+            assert_eq!(actions.floating, expected_floating);
+        }
     }
 }


### PR DESCRIPTION
Previously, when a window was set to full-screen, its size was set in `Clients::toggle_fullscreen` and future calls to `WindowManager::apply_layout` would ignore the state.

With this change, all positioning of fullscreen windows is done in the same places as for tiled windows.

Fixes #149

