### PR TITLE
Only focus client if it was not previously focused

### DIFF
--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -827,16 +827,16 @@ impl<X: XConn> WindowManager<X> {
             None => return Err(PenroseError::NoMatchingElement),
         };
 
-        // update focused client if there is a new client that is in focus
-        let wix = self.screens.active_ws_index();
-        let ws = self.workspaces.get_workspace(wix)?;
-        if let Some(fid) = ws.focused_client() {
-            if fid != id {
-                self.update_focus(id)?;
-                let screen = self.screens.focused();
-                self.conn.warp_cursor(Some(id), screen)?;
+        if let Some(wid) = self.active_workspace().focused_client() {
+            if wid == id {
+                return Ok(id);
             }
         }
+
+        // update focused client if there is a new client that is in focus
+        self.update_focus(id)?;
+        let screen = self.screens.focused();
+        self.conn.warp_cursor(Some(id), screen)?;
 
         Ok(id)
     }

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -826,9 +826,18 @@ impl<X: XConn> WindowManager<X> {
             Some(c) => c.id(),
             None => return Err(PenroseError::NoMatchingElement),
         };
-        self.update_focus(id)?;
-        let screen = self.screens.focused();
-        self.conn.warp_cursor(Some(id), screen)?;
+
+        // update focused client if there is a new client that is in focus
+        let wix = self.screens.active_ws_index();
+        let ws = self.workspaces.get_workspace(wix)?;
+        if let Some(fid) = ws.focused_client() {
+            if fid != id {
+                self.update_focus(id)?;
+                let screen = self.screens.focused();
+                self.conn.warp_cursor(Some(id), screen)?;
+            }
+        }
+
         Ok(id)
     }
 


### PR DESCRIPTION
This will fix bugs with e.g. steam, where if was constantly moving the
cursor to the center of the screen, and a similar issue with discord.

Resolves #192 