### PR TITLE
XF86 keymap fix

### DIFF
--- a/crates/penrose_keysyms/src/lib.rs
+++ b/crates/penrose_keysyms/src/lib.rs
@@ -2039,13 +2039,13 @@ pub enum XKeySym {
     #[strum(serialize = "XF86AudioNext")]
     XF86XK_AudioNext,
     /// XF86XK_AudioMicMute
-    #[strum(serialize = "XF86XK_AudioMicMute")]
+    #[strum(serialize = "XF86AudioMicMute")]
     XF86XK_AudioMicMute,
     /// XF86XK_DisplayOff
-    #[strum(serialize = "XF86XK_DisplayOff")]
+    #[strum(serialize = "XF86DisplayOff")]
     XF86XK_DisplayOff,
     /// XF86XK_TouchpadToggle
-    #[strum(serialize = "XF86XK_TouchpadToggle")]
+    #[strum(serialize = "XF86TouchpadToggle")]
     XF86XK_TouchpadToggle,
 }
 


### PR DESCRIPTION
Fixes #207. Might be worth writing a test to enforce the keyname -> enum variant relationship (Tab -> XK_Tab, XF86AudioMicMute -> XF86XK_AudioMicMute), but I do not know enough about proc macros to do that myself.