### PR TITLE
updating outdated example

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -166,9 +166,9 @@ fn main() -> penrose::Result<()> {
         "M-A-Right" => run_internal!(update_main_ratio, More);
         "M-A-Left" => run_internal!(update_main_ratio, Less);
 
-        refmap [ config.ws_range() ] in {
-            "M-{}" => focus_workspace [ index_selectors(config.workspaces().len()) ];
-            "M-S-{}" => client_to_workspace [ index_selectors(config.workspaces().len()) ];
+        map: { "1", "2", "3", "4", "5", "6", "7", "8", "9" } to index_selectors(9) => {
+            "M-{}" => focus_workspace (REF);
+            "M-S-{}" => client_to_workspace (REF);
         };
     };
 


### PR DESCRIPTION
The current gen_keybindings!() example used in the [getting_started](https://github.com/sminez/penrose/blob/develop/docs/getting_started.md) guide no longer works.   
This replaces the old example with the one used in the [crate documentation](https://docs.rs/penrose/latest/penrose/macro.gen_keybindings.html)