### PR TITLE
Symmetrical layouts

### DIFF
--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -13,7 +13,7 @@ use penrose::{
         config::Config,
         helpers::index_selectors,
         hooks::Hooks,
-        layout::{bottom_stack, side_stack, Layout, LayoutConf},
+        layout::{bottom_stack, right_stack, Layout, LayoutConf},
         xconnection::XConn,
     },
     logging_error_handler,
@@ -35,7 +35,7 @@ fn my_layouts() -> Vec<Layout> {
     };
 
     vec![
-        Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
+        Layout::new("[side]", LayoutConf::default(), right_stack, n_main, ratio),
         Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
         Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
     ]

--- a/examples/dynamic_workspaces/main.rs
+++ b/examples/dynamic_workspaces/main.rs
@@ -35,7 +35,7 @@ fn my_layouts() -> Vec<Layout> {
     };
 
     vec![
-        Layout::new("[side]", LayoutConf::default(), right_stack, n_main, ratio),
+        Layout::new("[right]", LayoutConf::default(), right_stack, n_main, ratio),
         Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
         Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
     ]
@@ -72,9 +72,9 @@ fn main() -> Result<()> {
     let hooks: Hooks<_> = vec![
         LayoutSymbolAsRootName::new(),
         RemoveEmptyWorkspaces::new(config.workspaces().clone()),
-        DefaultWorkspace::new("1term", "[side]", vec!["st"]),
+        DefaultWorkspace::new("1term", "[right]", vec!["st"]),
         DefaultWorkspace::new("2term", "[botm]", vec!["st", "st"]),
-        DefaultWorkspace::new("3term", "[side]", vec!["st", "st", "st"]),
+        DefaultWorkspace::new("3term", "[right]", vec!["st", "st", "st"]),
         DefaultWorkspace::new("web", "[papr]", vec!["firefox"]),
         DefaultWorkspace::new("files", "[botm]", vec!["thunar"]),
         sp.get_hook(),

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -19,7 +19,7 @@ use penrose::{
         config::Config,
         helpers::index_selectors,
         hooks::Hook,
-        layout::{bottom_stack, side_stack, Layout, LayoutConf},
+        layout::{bottom_stack, right_stack, Layout, LayoutConf},
         manager::WindowManager,
         ring::Selector,
         xconnection::{XConn, Xid},
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
     // Layouts to be used on each workspace. Currently all workspaces have the same set of Layouts
     // available to them, though they track modifications to n_main and ratio independently.
     config_builder.layouts(vec![
-        Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
+        Layout::new("[side]", LayoutConf::default(), right_stack, n_main, ratio),
         Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
         Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
         Layout::floating("[----]"),

--- a/examples/simple_config_with_hooks/main.rs
+++ b/examples/simple_config_with_hooks/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
     // Layouts to be used on each workspace. Currently all workspaces have the same set of Layouts
     // available to them, though they track modifications to n_main and ratio independently.
     config_builder.layouts(vec![
-        Layout::new("[side]", LayoutConf::default(), right_stack, n_main, ratio),
+        Layout::new("[right]", LayoutConf::default(), right_stack, n_main, ratio),
         Layout::new("[botm]", LayoutConf::default(), bottom_stack, n_main, ratio),
         Layout::new("[papr]", follow_focus_conf, paper, n_main, ratio),
         Layout::floating("[----]"),

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -41,7 +41,7 @@ __with_builder_and_getters! {
     ///     let ratio = 0.6;
     ///
     ///     vec![
-    ///         Layout::new("[side]", LayoutConf::default(), side_stack, n_main, ratio),
+    ///         Layout::new("[right]", LayoutConf::default(), side_stack, n_main, ratio),
     ///         Layout::new("[mono]", mono_conf, monocle, n_main, ratio),
     ///     ]
     /// }
@@ -74,7 +74,7 @@ __with_builder_and_getters! {
     /// You must provide at least one layout function
     Concrete layouts: Vec<Layout>; =>
         vec![
-            Layout::new("[side]", LayoutConf::default(), right_stack, 1, 0.6),
+            Layout::new("[right]", LayoutConf::default(), right_stack, 1, 0.6),
             Layout::floating("[----]"),
         ];
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,6 @@
 //! User facing configuration of the penrose [WindowManager][crate::core::manager::WindowManager].
 use crate::{
-    core::layout::{side_stack, Layout, LayoutConf},
+    core::layout::{right_stack, Layout, LayoutConf},
     draw::{Color, DrawError},
 };
 
@@ -74,7 +74,7 @@ __with_builder_and_getters! {
     /// You must provide at least one layout function
     Concrete layouts: Vec<Layout>; =>
         vec![
-            Layout::new("[side]", LayoutConf::default(), side_stack, 1, 0.6),
+            Layout::new("[side]", LayoutConf::default(), right_stack, 1, 0.6),
             Layout::floating("[----]"),
         ];
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -29,7 +29,7 @@ __with_builder_and_getters! {
     ///
     /// # Example
     /// ```
-    /// use penrose::core::{config::Config, layout::{LayoutConf, Layout, side_stack, monocle}};
+    /// use penrose::core::{config::Config, layout::{LayoutConf, Layout, right_stack, monocle}};
     ///
     /// fn my_layouts() -> Vec<Layout> {
     ///     let mono_conf = LayoutConf {
@@ -41,7 +41,7 @@ __with_builder_and_getters! {
     ///     let ratio = 0.6;
     ///
     ///     vec![
-    ///         Layout::new("[right]", LayoutConf::default(), side_stack, n_main, ratio),
+    ///         Layout::new("[right]", LayoutConf::default(), right_stack, n_main, ratio),
     ///         Layout::new("[mono]", mono_conf, monocle, n_main, ratio),
     ///     ]
     /// }

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -276,7 +276,7 @@ pub(crate) fn mock_layout(
 
 /// A simple layout that places the main region on the left and tiles remaining
 /// windows in a single column to the right.
-pub fn side_stack(
+pub fn right_stack(
     clients: &[&Client],
     _: Option<Xid>,
     monitor_region: &Region,
@@ -296,6 +296,37 @@ pub fn side_stack(
 
     let split = ((monitor_region.w as f32) * ratio) as u32;
     let (main, stack) = monitor_region.split_at_width(split).unwrap();
+
+    main.as_rows(max_main)
+        .into_iter()
+        .chain(stack.as_rows(n.saturating_sub(max_main)))
+        .zip(clients)
+        .map(|(r, c)| (c.id(), Some(r)))
+        .collect()
+}
+
+/// A simple layout that places the main region on the right and tiles remaining
+/// windows in a single column to the left.
+pub fn left_stack(
+    clients: &[&Client],
+    _: Option<Xid>,
+    monitor_region: &Region,
+    max_main: u32,
+    ratio: f32,
+) -> Vec<ResizeAction> {
+    let n = clients.len() as u32;
+
+    if n <= max_main || max_main == 0 {
+        return monitor_region
+            .as_rows(n)
+            .iter()
+            .zip(clients)
+            .map(|(r, c)| (c.id(), Some(*r)))
+            .collect();
+    }
+
+    let split = ((monitor_region.w as f32) * (1. - ratio)) as u32;
+    let (stack, main) = monitor_region.split_at_width(split).unwrap();
 
     main.as_rows(max_main)
         .into_iter()

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -367,6 +367,37 @@ pub fn bottom_stack(
         .collect()
 }
 
+/// A simple layout that places the main region at the bottom of the screen and tiles
+/// remaining windows in a single row above.
+pub fn top_stack(
+    clients: &[&Client],
+    _: Option<Xid>,
+    monitor_region: &Region,
+    max_main: u32,
+    ratio: f32,
+) -> Vec<ResizeAction> {
+    let n = clients.len() as u32;
+
+    if n <= max_main || max_main == 0 {
+        return monitor_region
+            .as_columns(n)
+            .iter()
+            .zip(clients)
+            .map(|(r, c)| (c.id(), Some(*r)))
+            .collect();
+    }
+
+    let split = ((monitor_region.h as f32) * (1. - ratio)) as u32;
+    let (stack, main) = monitor_region.split_at_height(split).unwrap();
+
+    main.as_columns(max_main)
+        .into_iter()
+        .chain(stack.as_columns(n.saturating_sub(max_main)))
+        .zip(clients)
+        .map(|(r, c)| (c.id(), Some(r)))
+        .collect()
+}
+
 /// A simple monolve layout that places uses the maximum available space for the focused client and
 /// unmaps all other windows.
 pub fn monocle(

--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -47,13 +47,13 @@
 //! those that have already been positioned if any of the Regions overlap one another.*
 //!
 //! This simple `rows` layout is a sub-set of the behaviour provided by the built in
-//! [side_stack][5] layout (in effect, clamping `max_main` at 0).
+//! [right_stack][5] layout (in effect, clamping `max_main` at 0).
 //!
 //! [1]: crate::core::client::Client
 //! [2]: crate::core::manager::WindowManager
 //! [3]: crate::core::data_types::Region
 //! [4]: crate::core::data_types::Region::as_rows
-//! [5]: crate::core::layout::side_stack
+//! [5]: crate::core::layout::right_stack
 use crate::core::{
     client::Client,
     data_types::{Change, Region, ResizeAction},

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -144,7 +144,7 @@ impl<X: XConn> WindowManager<X> {
     ///     contrib::hooks::{SpawnRule, ClientSpawnRules},
     ///     core::{
     ///         hooks::Hooks,
-    ///         layout::{floating, side_stack, LayoutFunc},
+    ///         layout::{floating, right_stack, LayoutFunc},
     ///         manager::WindowManager,
     ///     },
     ///     xcb::XcbConnection,
@@ -162,7 +162,7 @@ impl<X: XConn> WindowManager<X> {
     ///
     /// // The layout functions we were using previously
     /// let layout_funcs = map! {
-    ///     "[right]" => side_stack as LayoutFunc,
+    ///     "[right]" => right_stack as LayoutFunc,
     ///     "[----]" => floating as LayoutFunc,
     /// };
     ///

--- a/src/core/manager/mod.rs
+++ b/src/core/manager/mod.rs
@@ -162,7 +162,7 @@ impl<X: XConn> WindowManager<X> {
     ///
     /// // The layout functions we were using previously
     /// let layout_funcs = map! {
-    ///     "[side]" => side_stack as LayoutFunc,
+    ///     "[right]" => side_stack as LayoutFunc,
     ///     "[----]" => floating as LayoutFunc,
     /// };
     ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -38,7 +38,7 @@ pub fn simple_screen(n: usize) -> Screen {
 }
 
 fn layouts() -> Vec<Layout> {
-    vec![Layout::new("t", LayoutConf::default(), side_stack, 1, 0.6)]
+    vec![Layout::new("t", LayoutConf::default(), right_stack, 1, 0.6)]
 }
 
 pub fn test_bindings<X: XConn>() -> KeyBindings<X> {

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -86,7 +86,7 @@ __impl_stub_xcon! {
 
 fn layout_funcs() -> HashMap<&'static str, LayoutFunc> {
     map! {
-        "[side]" => right_stack as LayoutFunc,
+        "[right]" => right_stack as LayoutFunc,
         "[----]" => floating as LayoutFunc,
     }
 }

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -10,7 +10,7 @@ use penrose::{
     core::{
         client::Client,
         config::Config,
-        layout::{floating, side_stack, LayoutFunc},
+        layout::{floating, right_stack, LayoutFunc},
         manager::WindowManager,
         screen::Screen,
         xconnection::{Atom, Prop, Result, XError, XEvent, Xid},
@@ -86,7 +86,7 @@ __impl_stub_xcon! {
 
 fn layout_funcs() -> HashMap<&'static str, LayoutFunc> {
     map! {
-        "[side]" => side_stack as LayoutFunc,
+        "[side]" => right_stack as LayoutFunc,
         "[----]" => floating as LayoutFunc,
     }
 }


### PR DESCRIPTION
My recommended solution in #221 , with the following changes:

- rename `side_stack` to `right_stack`, changing all(?) documentation references accordingly
- implement a `left_stack` layout and a `top_stack` layout i.e. the counterparts to `right_stack` and `bottom_stack`
- give all(?) all `Layout`s using `right_stack` the symbol "[right]" instead of "[side]" (`right_stack` used to be called `side_stack`

This behaviour could be implemented easily by adding a boolean to the `LayoutFunc` arguments, where the boolean indicates whether or not the main/stack regions should be flipped. I'm not entirely sure if this is a good solution, as users may wish to define a layout with multiple non-main regions or something like that.