### PR TITLE
Added XF86Calculator keysym (Issue #236)

### DIFF
--- a/crates/penrose_keysyms/src/lib.rs
+++ b/crates/penrose_keysyms/src/lib.rs
@@ -2047,6 +2047,9 @@ pub enum XKeySym {
     /// XF86XK_TouchpadToggle
     #[strum(serialize = "XF86TouchpadToggle")]
     XF86XK_TouchpadToggle,
+    /// XF86XK_Calculator
+    #[strum(serialize = "XF86Calculator")]
+    XF86XK_Calculator,
 }
 
 impl XKeySym {
@@ -2732,6 +2735,7 @@ impl XKeySym {
                 XKeySym::XF86XK_AudioMicMute => 0x1008FF18,
                 XKeySym::XF86XK_DisplayOff => 0x1008FF19,
                 XKeySym::XF86XK_TouchpadToggle => 0x1008FF1A,
+                XKeySym::XF86XK_Calculator => 0x1008FF1D,
             } as u32)
                 .to_le_bytes()
                 .to_vec()


### PR DESCRIPTION
Added XF86Calculator keysym 
Referening [`X11/XF86keysym.h`](https://github.com/freedesktop/xorg-x11proto/blob/0657164905c607e1b2b1dbac2707b06460a9e2f4/XF86keysym.h)
Issue:#236