### PR TITLE
Update to x11rb 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = "1.0"
 tracing = { version = "0.1", features = ["attributes", "log"] }
 
 serde = { version = "1.0", features = ["derive"], optional = true }
-x11rb = { version = "0.10", features = ["randr"], optional = true }
+x11rb = { version = "0.11", features = ["randr"], optional = true }
 anymap = "0.12.1"
 
 [dev-dependencies]

--- a/crates/penrose_ui/Cargo.toml
+++ b/crates/penrose_ui/Cargo.toml
@@ -18,4 +18,4 @@ pango = { version = "0.15.6" }
 penrose = { version = "0.3", path = "../../" }
 tracing = { version = "0.1", features = ["attributes", "log"] }
 thiserror = "1.0.37"
-x11rb = { version = "0.10", features = ["randr", "render"] }
+x11rb = { version = "0.11", features = ["randr", "render"] }

--- a/src/x11rb/conversions.rs
+++ b/src/x11rb/conversions.rs
@@ -17,7 +17,7 @@ use tracing::warn;
 use x11rb::{
     connection::Connection,
     protocol::{
-        xproto::{ClientMessageEvent, ModMask},
+        xproto::{ClientMessageEvent, KeyButMask, ModMask},
         Event,
     },
 };
@@ -67,7 +67,7 @@ pub(crate) fn convert_event<C: Connection>(conn: &Conn<C>, event: Event) -> Resu
 
         Event::KeyPress(event) => {
             let code = KeyCode {
-                mask: event.state,
+                mask: event.state.into(),
                 code: event.detail,
             };
             let numlock = ModMask::M2;
@@ -144,7 +144,7 @@ pub(crate) fn convert_event<C: Connection>(conn: &Conn<C>, event: Event) -> Resu
     }
 }
 
-fn to_mouse_state(detail: u8, state: u16) -> Option<MouseState> {
+fn to_mouse_state(detail: u8, state: KeyButMask) -> Option<MouseState> {
     fn is_held(key: &ModifierKey, mask: u16) -> bool {
         mask & u16::from(*key) > 0
     }
@@ -159,6 +159,7 @@ fn to_mouse_state(detail: u8, state: u16) -> Option<MouseState> {
             return None;
         }
     };
+    let state = u16::from(state);
     let modifiers = ModifierKey::iter().filter(|m| is_held(m, state)).collect();
     Some(MouseState { button, modifiers })
 }

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     Error, Result, Xid,
 };
-use std::{collections::HashMap, convert::TryFrom, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 use strum::IntoEnumIterator;
 use tracing::error;
 use x11rb::{
@@ -277,17 +277,16 @@ where
         let modifiers = &[0, u16::from(ModMask::M2)];
         let mode = GrabMode::ASYNC;
         let mask = EventMask::BUTTON_PRESS | EventMask::BUTTON_RELEASE | EventMask::BUTTON_MOTION;
-        let mask = u16::try_from(u32::from(mask)).unwrap();
 
         for m in modifiers.iter() {
             for k in key_codes.iter() {
                 self.conn.grab_key(
-                    false,      // don't pass grabbed events through to the client
-                    self.root,  // the window to grab: in this case the root window
-                    k.mask | m, // modifiers to grab
-                    k.code,     // keycode to grab
-                    mode,       // don't lock pointer input while grabbing
-                    mode,       // don't lock keyboard input while grabbing
+                    false,               // don't pass grabbed events through to the client
+                    self.root,           // the window to grab: in this case the root window
+                    (k.mask | m).into(), // modifiers to grab
+                    k.code,              // keycode to grab
+                    mode,                // don't lock pointer input while grabbing
+                    mode,                // don't lock keyboard input while grabbing
                 )?;
             }
         }
@@ -296,15 +295,15 @@ where
             for state in mouse_states.iter() {
                 let button = state.button().into();
                 self.conn.grab_button(
-                    false,            // don't pass grabbed events through to the client
-                    self.root,        // the window to grab: in this case the root window
-                    mask,             // which events are reported to the client
-                    mode,             // don't lock pointer input while grabbing
-                    mode,             // don't lock keyboard input while grabbing
-                    x11rb::NONE,      // don't confine the cursor to a specific window
-                    x11rb::NONE,      // don't change the cursor type
-                    button,           // the button to grab
-                    state.mask() | m, // modifiers to grab
+                    false,                     // don't pass grabbed events through to the client
+                    self.root,                 // the window to grab: in this case the root window
+                    mask,                      // which events are reported to the client
+                    mode,                      // don't lock pointer input while grabbing
+                    mode,                      // don't lock keyboard input while grabbing
+                    x11rb::NONE,               // don't confine the cursor to a specific window
+                    x11rb::NONE,               // don't change the cursor type
+                    button,                    // the button to grab
+                    (state.mask() | m).into(), // modifiers to grab
                 )?;
             }
         }


### PR DESCRIPTION
x11rb switched to some stronger types for certain mask fields. Previously, these masks were represented as integers (e.g. u16). Now, special types are used that also represent the meaning of the mask, e.g. KeyButMask for a mask representing the state of certain keys and buttons.

This commit tries to do as few stuff as possible to fix this API breakage. x11rb provides Into implementations to go from u16 to KeyButMask.

Signed-off-by: Uli Schlachter <psychon@znc.in>