### PR TITLE
Remove note about 3.0 and git install in book

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -88,13 +88,7 @@ do just that with `tracing-subscriber`):
 
 ```bash
 $ cargo add tracing-subscriber --features env-filter
-```
-
-> **NOTE**: For now, you will need to add penrose as a git dependency. Once `v0.3.0` is stable
-> you will be able to add it in the same way as shown above for tracing-subscriber.
-
-```bash
-$ cargo add penrose --git https://github.com/sminez/penrose
+$ cargo add penrose
 ```
 
 With that done, we're going to copy the [minimal example][3] from the penrose repository in


### PR DESCRIPTION
The 3.0 note and git flag for the install seems outdated if I'm not mistaken. 

I'm just getting started and while reading through I went ahead and did this before I saw what the book said. But it seems to give the same version and given that the version seems to be stable now I assume it is fine? 

Just thought I might as well throw this up here when I noticed it.