### PR TITLE
Add support for dmenu-rs and more dmenu options.

### DIFF
--- a/src/extensions/actions/dynamic_select.rs
+++ b/src/extensions/actions/dynamic_select.rs
@@ -12,15 +12,9 @@ use std::collections::HashMap;
 /// Use [DMenu] to dynamically select and focus a client window.
 ///
 /// # Arguments
-/// * `DMenuConfig` users custom DMenuConfig, the dmenu instance that is launched will
-///    obey colorscheme, postion, etc..
-///
-/// * `custom_prompt` so the user isn't locked into a default prompt.
-///    Default: Window
-pub fn dmenu_focus_client<X: XConn>(
-    config: DMenuConfig,
-    custom_prompt: Option<String>,
-) -> Box<dyn KeyEventHandler<X>> {
+/// * `config` users custom DMenuConfig, the dmenu instance that is launched will
+///    obey colorscheme, postion, custom font, custom prompt etc...
+pub fn dmenu_focus_client<X: XConn>(mut config: DMenuConfig) -> Box<dyn KeyEventHandler<X>> {
     key_handler(move |state: &mut State<X>, x: &X| {
         let choices: HashMap<String, Xid> = state
             .client_set
@@ -36,11 +30,10 @@ pub fn dmenu_focus_client<X: XConn>(
             .collect();
 
         let screen = state.client_set.current_screen().index();
-        let dmenu: DMenu = if custom_prompt.is_some() {
-            DMenu::new(custom_prompt.to_owned(), &config, screen)
-        } else {
-            DMenu::new(Some("Window:".to_owned()), &config, screen)
-        };
+        if config.custom_prompt.is_none() {
+            config.custom_prompt = Some("Window: ".to_owned());
+        }
+        let dmenu = DMenu::new(&config, screen);
 
         if let MenuMatch::Line(_, s) = dmenu.build_menu(choices.keys().collect())? {
             let id = choices
@@ -57,24 +50,18 @@ pub fn dmenu_focus_client<X: XConn>(
 /// Use [DMenu] to dynamically select and focus a client window.
 ///
 /// # Arguments
-/// * `DMenuConfig` users custom DMenuConfig, the dmenu instance that is launched will
-///    obey colorscheme, postion, etc..
-///
-/// * `custom_prompt` so the user isn't locked into a default prompt.
-///    Default: Workspace
-pub fn dmenu_focus_tag<X: XConn>(
-    config: DMenuConfig,
-    custom_prompt: Option<String>,
-) -> Box<dyn KeyEventHandler<X>> {
+/// * `config` users custom DMenuConfig, the dmenu instance that is launched will
+///    obey colorscheme, postion, custom font, custom prompt etc...
+pub fn dmenu_focus_tag<X: XConn>(mut config: DMenuConfig) -> Box<dyn KeyEventHandler<X>> {
     key_handler(move |state: &mut State<X>, x: &X| {
         let choices = state.client_set.ordered_tags();
         let screen = state.client_set.current_screen().index();
 
-        let dmenu: DMenu = if custom_prompt.is_some() {
-            DMenu::new(custom_prompt.to_owned(), &config, screen)
-        } else {
-            DMenu::new(Some("Window:".to_owned()), &config, screen)
-        };
+        if config.custom_prompt.is_none() {
+            config.custom_prompt = Some("Workspace: ".to_owned());
+        }
+
+        let dmenu = DMenu::new(&config, screen);
 
         if let MenuMatch::Line(_, tag) = dmenu.build_menu(choices)? {
             x.modify_and_refresh(state, |cs| cs.focus_tag(&tag))?;
@@ -87,23 +74,15 @@ pub fn dmenu_focus_tag<X: XConn>(
 /// Launch [DMenu] for its most basic purposes, launching other programs.
 ///
 /// # Arguments
-/// * `DMenuConfig` users custom DMenuConfig, the dmenu instance that is launched will
-///    obey colorscheme, postion, etc..
-///
-/// * `custom_prompt` so the user isn't locked into a default prompt.
-///    Default: >>>
-pub fn launch_dmenu<X: XConn>(
-    config: DMenuConfig,
-    custom_prompt: Option<String>,
-) -> Box<dyn KeyEventHandler<X>> {
+/// * `config` users custom DMenuConfig, the dmenu instance that is launched will
+///    obey colorscheme, postion, custom font, custom prompt etc...
+pub fn launch_dmenu<X: XConn>(mut config: DMenuConfig) -> Box<dyn KeyEventHandler<X>> {
     key_handler(move |state, _| {
         let screen = state.client_set.current_screen().index();
-
-        let dmenu: DMenu = if custom_prompt.is_some() {
-            DMenu::new(custom_prompt.to_owned(), &config, screen)
-        } else {
-            DMenu::new(Some(">>> ".to_owned()), &config, screen)
-        };
+        if config.custom_prompt.is_none() {
+            config.custom_prompt = Some(">>> ".to_owned());
+        }
+        let dmenu = DMenu::new(&config, screen);
         dmenu.run()
     })
 }

--- a/src/extensions/util/dmenu.rs
+++ b/src/extensions/util/dmenu.rs
@@ -1,6 +1,6 @@
 //! A simple wrapper for suckless' [dmenu][1] tool for providing quick text based menus
 //!
-//! [1]: https://tools.suckless.org/dmenu/
+//! See [`DMenuKind`] for dmenu type support options.
 use crate::{Color, Error, Result};
 use std::{
     io::{Read, Write},
@@ -18,22 +18,57 @@ pub enum MenuMatch {
     NoMatch,
 }
 
-/// Config for running a [DMenu] selection
-#[derive(Debug, Copy, Clone)]
+/// Two different derivatives of dmenu
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DMenuKind {
+    /// Suckless's version of dmenu
+    ///
+    /// [1]: https://tools.suckless.org/dmenu/
+    Suckless,
+    /// Newer `dmenu-rs`
+    ///
+    /// [1]: https://github.com/Shizcow/dmenu-rs
+    Rust,
+}
+
+/// Custom configuration options for [`DMenu`].
+///
+/// # Example
+/// ```no_run
+/// # use penrose::extensions::util::dmenu::*;
+/// let dc = DMenuConfig {
+///     show_line_numbers: true,
+///     show_on_bottom: true,
+///     password_input: true,
+///     ignore_case: false,
+///     n_lines: 20,
+///     custom_font: Some("JetBrains Nerd Font Mono".to_owned()),
+///     kind: DMenuKind::Rust,
+///     ..DMenuConfig::default()
+/// };
+/// ```
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
 pub struct DMenuConfig {
     /// Should line numbers be displayed to the user?
     ///
     /// Default: false
     pub show_line_numbers: bool,
 
+    /// Show dmenu at the bottom the the screen.
+    ///
+    /// Default: false
+    pub show_on_bottom: bool,
+
     /// Should dmenu treat the input as a password and render characters as '*'?
     ///
-    /// # NOTE
-    /// This requires the [Password][1] patch in order to work.
+    /// NOTE: This requires the [Password][1] patch in order to work.
+    /// or in the case of dmenu-rs it requires the password plugin.
     ///
     /// Default: false
     ///
     /// [1]: https://tools.suckless.org/dmenu/patches/password/
+    /// [1]: https://github.com/Shizcow/dmenu-rs/tree/master/src/plugins
     pub password_input: bool,
 
     /// Should dmenu ignore case in the user input when matching?
@@ -63,59 +98,93 @@ pub struct DMenuConfig {
     ///
     /// Default: 10
     pub n_lines: u8,
+
+    /// Allow the user to load a custom font
+    ///
+    /// Default: None
+    pub custom_font: Option<String>,
+
+    /// Specify to kind of dmenu to use
+    ///
+    /// Default: Suckless
+    pub kind: DMenuKind,
 }
 
 impl Default for DMenuConfig {
     fn default() -> Self {
         Self {
             show_line_numbers: false,
+            show_on_bottom: false,
             password_input: false,
             ignore_case: false,
             bg_color: 0x282828ff.into(),
             fg_color: 0xebdbb2ff.into(),
             selected_color: 0x458588ff.into(),
             n_lines: 10,
+            custom_font: None,
+            kind: DMenuKind::Suckless,
         }
     }
 }
 
 impl DMenuConfig {
-    fn flags(&self, prompt: &str, screen_index: usize) -> Vec<String> {
-        let &DMenuConfig {
+    /// Build the dmenu flags
+    fn flags(&self, custom_prompt: &Option<String>, screen_index: usize) -> Vec<String> {
+        let Self {
+            show_on_bottom,
             password_input,
             ignore_case,
             bg_color,
             fg_color,
             selected_color,
             n_lines,
+            custom_font,
+            kind,
             ..
         } = self;
 
-        let mut flags = vec![
-            "-nb".to_string(),
-            bg_color.as_rgb_hex_string(),
-            "-nf".to_string(),
-            fg_color.as_rgb_hex_string(),
-            "-sb".to_string(),
-            selected_color.as_rgb_hex_string(),
-            "-m".to_string(),
-            screen_index.to_string(),
-        ];
+        // Only some command line options require the "--" for the rust version.
+        let prefix = match kind {
+            DMenuKind::Suckless => "-",
+            DMenuKind::Rust => "--",
+        };
 
-        if n_lines > 0 {
-            flags.extend_from_slice(&["-l".to_string(), n_lines.to_string()]);
+        let mut flags = vec!["-m".to_owned(), screen_index.to_string()];
+
+        flags.push(format!("{prefix}nb"));
+        flags.push(bg_color.as_rgb_hex_string());
+
+        flags.push(format!("{prefix}nf"));
+        flags.push(fg_color.as_rgb_hex_string());
+
+        flags.push(format!("{prefix}sb"));
+        flags.push(selected_color.as_rgb_hex_string());
+
+        if *n_lines > 0 {
+            flags.push("-l".to_owned());
+            flags.push(n_lines.to_string());
         }
 
-        if password_input {
-            flags.push("-P".to_string());
+        if *show_on_bottom {
+            flags.push("-b".to_owned());
         }
 
-        if ignore_case {
-            flags.push("-i".to_string());
+        if *password_input {
+            flags.push("-P".to_owned());
         }
 
-        if !prompt.is_empty() {
-            flags.extend_from_slice(&["-p".to_string(), prompt.to_string()]);
+        if *ignore_case {
+            flags.push("-i".to_owned());
+        }
+
+        if let Some(font) = custom_font {
+            flags.push(format!("{prefix}fn"));
+            flags.push(font.to_owned());
+        }
+
+        if let Some(prompt) = custom_prompt {
+            flags.push("-p".to_owned());
+            flags.push(prompt.to_owned());
         }
 
         flags
@@ -124,89 +193,112 @@ impl DMenuConfig {
 
 /// A wrapper around the suckless [dmenu][1] program for creating dynamic menus
 /// in penrose.
-///
-/// [1]: https://tools.suckless.org/dmenu/
 #[derive(Debug, Clone)]
 pub struct DMenu {
+    /// Optional prompt customization.
+    prompt: Option<String>,
+    /// Holds the custom dmenu configuration for this instance.
     config: DMenuConfig,
-    prompt: String,
-    choices: Vec<String>,
+    /// The screen index this instance of dmenu will show up on
+    screen_index: usize,
 }
 
 impl DMenu {
-    /// Create a new [DMenu] command which can be triggered and re-used by calling the `run` method
-    pub fn new(
-        prompt: impl Into<String>,
-        choices: Vec<impl Into<String>>,
-        config: DMenuConfig,
-    ) -> Self {
+    /// Create a new [`DMenu`] command which can be triggered and reused by calling
+    /// the `run` method.
+    pub fn new(prompt: Option<String>, config: &DMenuConfig, screen_index: usize) -> Self {
         Self {
-            prompt: prompt.into(),
-            choices: choices.into_iter().map(|s| s.into()).collect(),
-            config,
+            prompt,
+            config: config.to_owned(),
+            screen_index,
         }
     }
 
-    /// Run this [DMenu] command and return the selected choice.
+    /// Used for launching regular old [`DMenu`] with no menu matching.
+    pub fn run(&self) -> Result<()> {
+        let args = self.config.flags(&self.prompt, self.screen_index);
+        let spawned_process = Command::new("dmenu_run").args(args).spawn();
+
+        match spawned_process {
+            Ok(mut process) => match process.wait() {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e.into()),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Run this [`DMenu`] command and return the selected choice.
     ///
     /// # Example
     /// ```no_run
     /// # use penrose::extensions::util::dmenu::*;
-    /// let lines = vec!["some", "choices", "to", "pick", "from"];
-    /// let menu = DMenu::new(">>>", lines, DMenuConfig::default());
-    ///
     /// let screen_index = 0;
+    /// let dmenu = DMenu::new(Some(">>>".to_owned()), &DMenuConfig::default(), screen_index);
     ///
-    /// match menu.run(screen_index).unwrap() {
+    /// let choices = vec!["some", "choices", "to", "pick", "from"];
+    ///
+    /// match dmenu.build_menu(choices).unwrap() {
     ///     MenuMatch::Line(i, s) => println!("matched '{}' on line '{}'", s, i),
     ///     MenuMatch::UserInput(s) => println!("user input: '{}'", s),
     ///     MenuMatch::NoMatch => println!("no match"),
     /// }
     /// ```
-    pub fn run(&self, screen_index: usize) -> Result<MenuMatch> {
-        let raw = self.raw_user_choice_from_dmenu(screen_index)?;
+    #[allow(clippy::pattern_type_mismatch)]
+    pub fn build_menu(&self, param_choices: Vec<impl Into<String>>) -> Result<MenuMatch> {
+        let choices: Vec<String> = param_choices
+            .into_iter()
+            .map(std::convert::Into::into)
+            .collect();
+        let raw = self.raw_user_choice_from_dmenu(&choices)?;
         let choice = raw.trim();
 
         if choice.is_empty() {
             return Ok(MenuMatch::NoMatch);
         }
 
-        let res = self
-            .choices
+        let res = choices
             .iter()
             .enumerate()
             .find(|(i, s)| {
                 if self.config.show_line_numbers {
-                    format!("{:<3} {}", i, s) == choice
+                    format!("{i:<3} {s}") == choice
                 } else {
                     *s == choice
                 }
             })
             .map_or_else(
-                || MenuMatch::UserInput(choice.to_string()),
-                |(i, _)| MenuMatch::Line(i, self.choices[i].to_string()),
+                || MenuMatch::UserInput(choice.to_owned()),
+                |(i, _)| {
+                    MenuMatch::Line(
+                        i,
+                        choices.get(i).expect("Indexing choices panicked").clone(),
+                    )
+                },
             );
 
         Ok(res)
     }
 
-    fn choices_as_input_bytes(&self) -> Vec<u8> {
-        let choices = if self.config.show_line_numbers {
-            self.choices
+    /// Get a vector of choices as bytes
+    fn choices_as_input_bytes(&self, choices: &[String]) -> Vec<u8> {
+        if self.config.show_line_numbers {
+            choices
                 .iter()
                 .enumerate()
-                .map(|(i, s)| format!("{:<3} {}", i, s))
+                .map(|(i, s)| format!("{i:<3} {s}"))
                 .collect::<Vec<String>>()
                 .join("\n")
+                .as_bytes()
+                .to_vec()
         } else {
-            self.choices.join("\n")
-        };
-
-        choices.as_bytes().to_vec()
+            choices.join("\n").as_bytes().to_vec()
+        }
     }
 
-    fn raw_user_choice_from_dmenu(&self, screen_index: usize) -> Result<String> {
-        let args = self.config.flags(&self.prompt, screen_index);
+    /// Launch a shell process with all arguments to dmenu
+    fn raw_user_choice_from_dmenu(&self, choices: &[String]) -> Result<String> {
+        let args = self.config.flags(&self.prompt, self.screen_index);
         let mut proc = Command::new("dmenu")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -221,7 +313,7 @@ impl DMenu {
                 .take()
                 .ok_or_else(|| Error::Custom("unable to open stdin".to_owned()))?;
 
-            stdin.write_all(&self.choices_as_input_bytes())?;
+            stdin.write_all(&self.choices_as_input_bytes(choices))?;
         }
 
         let mut raw = String::new();
@@ -230,5 +322,76 @@ impl DMenu {
             .read_to_string(&mut raw)?;
 
         Ok(raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DMenuConfig, DMenuKind};
+
+    /// Flags [ nb, nf, sb, and nf] need to be modified for the different
+    /// versions of dmenu. Classic Suckless dmenu uses a single dash "-", dmenu-rs
+    /// uses the more modern cli style of double dashes "--".
+    /// This test depends on the order the flags are loaded into the array, so if the order
+    /// is changed in the flags function, these tests will fail. There is a better way, but
+    /// this works for now.
+    #[test]
+    fn dmenu_suckless_config_test() {
+        let dc = DMenuConfig {
+            custom_font: Some("mono".to_owned()),
+            ..DMenuConfig::default()
+        };
+
+        // Should default to suckless c-style dmenu
+        assert_eq!(dc.kind, DMenuKind::Suckless);
+        let flags = dc.flags(&None, 0);
+
+        for (i, flag) in flags.into_iter().enumerate() {
+            if i == 2 {
+                assert_eq!(flag, "-nb".to_owned());
+            }
+            if i == 4 {
+                assert_eq!(flag, "-nf".to_owned());
+            }
+            if i == 6 {
+                assert_eq!(flag, "-sb".to_owned());
+            }
+            if i == 10 {
+                assert_eq!(flag, "-fn".to_owned());
+            }
+        }
+    }
+
+    /// Flags [ nb, nf, sb, and nf] need to be modified for the different
+    /// versions of dmenu. Classic Suckless dmenu uses a single dash "-", dmenu-rs
+    /// uses the more modern cli style of double dashes "--".
+    /// This test depends on the order the flags are loaded into the array, so if the order
+    /// is changed in the flags function, these tests will fail. There is a better way, but
+    /// this works for now.
+    #[test]
+    fn dmenu_rs_config_test() {
+        let dc = DMenuConfig {
+            custom_font: Some("mono".to_owned()),
+            kind: DMenuKind::Rust,
+            ..DMenuConfig::default()
+        };
+
+        assert_eq!(dc.kind, DMenuKind::Rust);
+        let flags = dc.flags(&None, 0);
+
+        for (i, flag) in flags.into_iter().enumerate() {
+            if i == 2 {
+                assert_eq!(flag, "--nb".to_owned());
+            }
+            if i == 4 {
+                assert_eq!(flag, "--nf".to_owned());
+            }
+            if i == 6 {
+                assert_eq!(flag, "--sb".to_owned());
+            }
+            if i == 10 {
+                assert_eq!(flag, "--fn".to_owned());
+            }
+        }
     }
 }


### PR DESCRIPTION
### RESOLVES #265  
Custom font is now supported with -fn, display dmenu on bottom with -b. Added optional custom prompts to `src/extensions/actions/dynamic_select.rs` so the user isn't stuck with a default prompt. Added a new function which just spawns dmenu with a custom prompt and config, as it seems like a sane default/nicety to have in the extensions.

The DMenu api has changed a bit now, with the run function being changed to simply spawn regular ol' dmenu via `dmenu_run`, and a new `build_menu` method which has the same functionality as the old run method, but some parameters have been switch around. The `screen_index` is now passed into the `DMenu::new` constructor as it makes more sense, and the choices Vector is no longer held in the struct as that was not really needed, it is now just passed into the `build_menu` method and gets passed around as a reference to the private methods. Unit tests were added, some more documentation. All tests are passing, and I tried the modifications on my setup and everything works fine. Although you never know if any regressions were added.

### EDIT

Custom prompt moved into DMenuConfig struct