### PR TITLE
Issue 272 - removing the dependency on pango and cairo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
 
     - name: Install C deps
-      run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
+      run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libxft-dev --fix-missing
 
     - name: Run tests
       run: cargo test --workspace --features ${{ matrix.features }} --verbose
@@ -55,7 +55,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         components: clippy
-    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
+    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libxft-dev --fix-missing
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,5 +70,5 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: nightly
-    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
+    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libxft-dev --fix-missing
     - run: cargo rustdoc --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
 
     - name: Install C deps
-      run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
+      run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
 
     - name: Run tests
       run: cargo test --workspace --features ${{ matrix.features }} --verbose
@@ -55,7 +55,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         components: clippy
-    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
+    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,5 +70,5 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: nightly
-    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev libpango1.0-dev libcairo2-dev --fix-missing
+    - run: sudo apt-get update && sudo apt-get install -y libxrandr-dev libx11-xcb-dev libxcb-randr0-dev --fix-missing
     - run: cargo rustdoc --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -23,24 +23,21 @@ members = [
 ]
 
 [features]
-default = ["x11rb-xcb", "keysyms"]
+default = ["x11rb", "keysyms"]
 keysyms = ["penrose_keysyms"]
 x11rb-xcb = ["x11rb", "x11rb/allow-unsafe-code"]
 
 [dependencies]
-penrose_keysyms = { version = "0.1.1", path = "crates/penrose_keysyms", optional = true }
-# penrose_proc = { version = "0.1.3", path = "crates/penrose_proc" }
-
+anymap = "0.12"
 bitflags = { version = "2.3", features = ["serde"] }
-nix = "0.26"
+nix = { version = "0.26", default-features = false, features = ["signal"] }
+penrose_keysyms = { version = "0.3", path = "crates/penrose_keysyms", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 strum = { version = "0.25", features = ["derive"] }
 strum_macros = "0.25"
 thiserror = "1.0"
-tracing = { version = "0.1", features = ["attributes", "log"] }
-
-serde = { version = "1.0", features = ["derive"], optional = true }
+tracing = { version = "0.1", features = ["attributes"] }
 x11rb = { version = "0.12", features = ["randr"], optional = true }
-anymap = "0.12"
 
 [dev-dependencies]
 paste = "1.0.13"

--- a/crates/penrose_keysyms/Cargo.toml
+++ b/crates/penrose_keysyms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_keysyms"
-version = "0.1.1"
+version = "0.3.3"
 authors = ["IDAM <innes.andersonmorrison@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/penrose_keysyms/LICENSE
+++ b/crates/penrose_keysyms/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Innes Anderson-Morrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/penrose_ui/Cargo.toml
+++ b/crates/penrose_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_ui"
-version = "0.3.4"
+version = "0.3.3"
 edition = "2021"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -13,11 +13,10 @@ description = "UI elements for the penrose window manager library"
 
 [dependencies]
 penrose = { version = "0.3", path = "../../" }
-tracing = { version = "0.1", features = ["attributes", "log"] }
+tracing = { version = "0.1", features = ["attributes"] }
 thiserror = "1.0"
-yeslogic-fontconfig-sys = "4.0.1"
-x11 = { version = "2.21.0", features = ["xft", "xlib"] }
-x11rb = "0.12.0"
+yeslogic-fontconfig-sys = "4.0"
+x11 = { version = "2.21", features = ["xft", "xlib"] }
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/crates/penrose_ui/Cargo.toml
+++ b/crates/penrose_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_ui"
-version = "0.1.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -12,10 +12,12 @@ description = "UI elements for the penrose window manager library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cairo-rs = { version = "0.17.10", features = ["xcb"] }
-pangocairo = { version = "0.17.10" }
-pango = { version = "0.17.10" }
 penrose = { version = "0.3", path = "../../" }
 tracing = { version = "0.1", features = ["attributes", "log"] }
 thiserror = "1.0"
-x11rb = { version = "0.12", features = ["randr", "render"] }
+yeslogic-fontconfig-sys = "4.0.1"
+x11 = { version = "2.21.0", features = ["xft", "xlib"] }
+x11rb = "0.12.0"
+
+[dev-dependencies]
+anyhow = "1.0.71"

--- a/crates/penrose_ui/LICENSE
+++ b/crates/penrose_ui/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Innes Anderson-Morrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/penrose_ui/README.md
+++ b/crates/penrose_ui/README.md
@@ -2,5 +2,10 @@
 
 _GUI elements for the penrose window manager library_
 
+The functionality provided by this crate is a _very_ thin wrapper over xlib and fontconfig
+to support minimal text based UIs such as a status bar or simple menu. It may be possible
+to use this to write a stand alone UI outside of direct integration with the Penrose window
+manager crate but that is not the supported use case this crate has been written for.
+
 ## Bar
 A lightweight and minimal status bar.

--- a/crates/penrose_ui/examples/txt-demo.rs
+++ b/crates/penrose_ui/examples/txt-demo.rs
@@ -1,0 +1,51 @@
+//! Demo of the text rendering API
+use penrose::{
+    pure::geometry::Rect,
+    x::{Atom, WinType},
+    Color,
+};
+use penrose_ui::Draw;
+use std::{thread::sleep, time::Duration};
+
+const DX: u32 = 100;
+const DY: u32 = 100;
+const W: u32 = 500;
+const H: u32 = 60;
+const FONT: &str = "ProFont For Powerline";
+const TXT: &str = "    text is great! ◈ ζ ᛄ ℚ";
+
+fn main() -> anyhow::Result<()> {
+    let fg1 = Color::try_from("#fad07b")?;
+    let fg2 = Color::try_from("#458588")?;
+    let fg3 = Color::try_from("#a6cc70")?;
+    let fg4 = Color::try_from("#b16286")?;
+    let bg = Color::try_from("#282828")?;
+
+    let mut drw = Draw::new(FONT, 12, bg)?;
+    let w = drw.new_window(
+        WinType::InputOutput(Atom::NetWindowTypeDock),
+        Rect::new(DX, DY, W, H),
+        false,
+    )?;
+
+    let mut ctx = drw.context_for(w)?;
+    ctx.clear()?;
+
+    let (dx, dy) = ctx.draw_text(TXT, 0, (10, 0), fg1)?;
+
+    ctx.set_x_offset(dx as i32 + 10);
+    ctx.draw_text(TXT, 0, (5, 0), fg2)?;
+
+    ctx.translate(0, dy as i32 + 10);
+    ctx.draw_text(TXT, 0, (5, 0), fg3)?;
+
+    ctx.translate(-(dx as i32), 0);
+    ctx.draw_text(TXT, 0, (0, 0), fg4)?;
+
+    ctx.flush();
+    drw.flush(w)?;
+
+    sleep(Duration::from_secs(2));
+
+    Ok(())
+}

--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -8,7 +8,6 @@ use penrose::{
 };
 use std::fmt;
 use tracing::{debug, error, info};
-use x11rb::protocol::xproto::ConnectionExt;
 
 pub mod widgets;
 
@@ -240,7 +239,7 @@ pub fn event_hook<X: XConn + 'static>(
 
         for &(id, _) in bar.screens.iter() {
             info!(%id, "removing previous status bar");
-            bar.draw.conn.connection().destroy_window(*id)?;
+            bar.draw.conn.destroy_window(id)?;
         }
 
         if let Err(e) = bar.init_for_screens() {

--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -236,10 +236,13 @@ pub fn event_hook<X: XConn + 'static>(
 
     if matches!(event, RandrNotify) || matches!(event, ConfigureNotify(e) if e.is_root) {
         info!("screens have changed: recreating status bars");
+        let screens: Vec<_> = bar.screens.drain(0..).collect();
 
-        for &(id, _) in bar.screens.iter() {
+        for (id, _) in screens {
             info!(%id, "removing previous status bar");
-            bar.draw.conn.destroy_window(id)?;
+            if let Err(e) = bar.draw.destroy_window_and_surface(id) {
+                error!(%e, "error when removing previous status bar state");
+            }
         }
 
         if let Err(e) = bar.init_for_screens() {

--- a/crates/penrose_ui/src/bar/widgets/debug.rs
+++ b/crates/penrose_ui/src/bar/widgets/debug.rs
@@ -22,11 +22,11 @@ impl ActiveWindowId {
 }
 
 impl<X: XConn> Widget<X> for ActiveWindowId {
-    fn draw(&mut self, ctx: &mut Context, s: usize, focused: bool, w: f64, h: f64) -> Result<()> {
-        Widget::<X>::draw(&mut self.inner, ctx, s, focused, w, h)
+    fn draw(&mut self, ctx: &mut Context<'_>, s: usize, f: bool, w: u32, h: u32) -> Result<()> {
+        Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, h: u32) -> Result<(u32, u32)> {
         Widget::<X>::current_extent(&mut self.inner, ctx, h)
     }
 
@@ -72,11 +72,11 @@ impl StateSummary {
 }
 
 impl<X: XConn> Widget<X> for StateSummary {
-    fn draw(&mut self, ctx: &mut Context, s: usize, focused: bool, w: f64, h: f64) -> Result<()> {
-        Widget::<X>::draw(&mut self.inner, ctx, s, focused, w, h)
+    fn draw(&mut self, ctx: &mut Context<'_>, s: usize, f: bool, w: u32, h: u32) -> Result<()> {
+        Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, h: u32) -> Result<(u32, u32)> {
         Widget::<X>::current_extent(&mut self.inner, ctx, h)
     }
 

--- a/crates/penrose_ui/src/bar/widgets/debug.rs
+++ b/crates/penrose_ui/src/bar/widgets/debug.rs
@@ -14,7 +14,7 @@ pub struct ActiveWindowId {
 
 impl ActiveWindowId {
     /// Create a new ActiveWindowId widget.
-    pub fn new(style: &TextStyle, is_greedy: bool, right_justified: bool) -> Self {
+    pub fn new(style: TextStyle, is_greedy: bool, right_justified: bool) -> Self {
         Self {
             inner: Text::new("", style, is_greedy, right_justified),
         }
@@ -60,7 +60,7 @@ pub struct StateSummary {
 
 impl StateSummary {
     /// Create a new StateSummary widget.
-    pub fn new(style: &TextStyle) -> Self {
+    pub fn new(style: TextStyle) -> Self {
         Self {
             inner: Text::new("", style, false, false),
             cfg: CurrentStateConfig {

--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -142,9 +142,6 @@ impl<X: XConn> Widget<X> for Text {
         }
 
         let (ew, eh) = <Self as Widget<X>>::current_extent(self, ctx, h)?;
-        // ctx.font(&self.font, self.point_size)?;
-        // ctx.color(&self.fg);
-
         let offset = w as i32 - ew as i32;
         let right_justify = self.right_justified && self.is_greedy && offset > 0;
         if right_justify {
@@ -165,7 +162,6 @@ impl<X: XConn> Widget<X> for Text {
             Some(extent) => Ok(extent),
             None => {
                 let (l, r) = self.padding;
-                // ctx.font(&self.font, self.point_size)?;
                 let (w, h) = ctx.text_extent(&self.txt)?;
                 let extent = (w + l + r, h);
                 self.extent = Some(extent);

--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -81,8 +81,6 @@ where
 #[derive(Clone, Debug, PartialEq)]
 pub struct Text {
     txt: String,
-    font: String,
-    point_size: u8,
     fg: Color,
     bg: Option<Color>,
     padding: (u32, u32),
@@ -96,14 +94,12 @@ impl Text {
     /// Construct a new [Text]
     pub fn new(
         txt: impl Into<String>,
-        style: &TextStyle,
+        style: TextStyle,
         is_greedy: bool,
         right_justified: bool,
     ) -> Self {
         Self {
             txt: txt.into(),
-            font: style.font.clone(),
-            point_size: style.point_size,
             fg: style.fg,
             bg: style.bg,
             padding: style.padding,
@@ -213,11 +209,9 @@ impl<X: XConn> Widget<X> for Text {
 /// }
 ///
 /// let style = TextStyle {
-///     font: "mono".to_string(),
-///     point_size: 10,
 ///     fg: 0xebdbb2ff.into(),
 ///     bg: Some(0x282828ff.into()),
-///     padding: (2.0, 2.0),
+///     padding: (2, 2),
 /// };
 ///
 /// let my_widget = RefreshText::new(&style, my_get_text);
@@ -238,7 +232,7 @@ impl fmt::Debug for RefreshText {
 impl RefreshText {
     /// Construct a new [`RefreshText`] using the specified styling and a function for
     /// generating the widget contents.
-    pub fn new<F>(style: &TextStyle, get_text: F) -> Self
+    pub fn new<F>(style: TextStyle, get_text: F) -> Self
     where
         F: Fn() -> String + 'static,
     {
@@ -302,11 +296,9 @@ impl<X: XConn> Widget<X> for RefreshText {
 /// }
 ///
 /// let style = TextStyle {
-///     font: "mono".to_string(),
-///     point_size: 10,
 ///     fg: 0xebdbb2ff.into(),
 ///     bg: Some(0x282828ff.into()),
-///     padding: (2.0, 2.0),
+///     padding: (2, 2),
 /// };
 ///
 ///
@@ -325,7 +317,7 @@ impl IntervalText {
     /// Construct a new [`IntervalText`] using the specified styling and a function for
     /// generating the widget contents. The function for updating the widget contents
     /// will be run in its own thread on the interval provided.
-    pub fn new<F>(style: &TextStyle, get_text: F, interval: Duration) -> Self
+    pub fn new<F>(style: TextStyle, get_text: F, interval: Duration) -> Self
     where
         F: Fn() -> String + 'static + Send,
     {

--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -214,7 +214,7 @@ impl<X: XConn> Widget<X> for Text {
 ///     padding: (2, 2),
 /// };
 ///
-/// let my_widget = RefreshText::new(&style, my_get_text);
+/// let my_widget = RefreshText::new(style, my_get_text);
 /// ```
 pub struct RefreshText {
     inner: Text,
@@ -303,7 +303,7 @@ impl<X: XConn> Widget<X> for RefreshText {
 ///
 ///
 /// let my_widget = IntervalText::new(
-///     &style,
+///     style,
 ///     my_get_text,
 ///     Duration::from_secs(60 * 5)
 /// );

--- a/crates/penrose_ui/src/bar/widgets/simple.rs
+++ b/crates/penrose_ui/src/bar/widgets/simple.rs
@@ -17,7 +17,7 @@ pub struct RootWindowName {
 
 impl RootWindowName {
     /// Create a new RootWindowName widget
-    pub fn new(style: &TextStyle, is_greedy: bool, right_justified: bool) -> Self {
+    pub fn new(style: TextStyle, is_greedy: bool, right_justified: bool) -> Self {
         Self {
             inner: Text::new("penrose", style, is_greedy, right_justified),
         }
@@ -69,12 +69,7 @@ impl ActiveWindowName {
     /// Create a new ActiveWindowName widget with a maximum character count.
     ///
     /// max_chars can not be lower than 3.
-    pub fn new(
-        max_chars: usize,
-        style: &TextStyle,
-        is_greedy: bool,
-        right_justified: bool,
-    ) -> Self {
+    pub fn new(max_chars: usize, style: TextStyle, is_greedy: bool, right_justified: bool) -> Self {
         Self {
             inner: Text::new("", style, is_greedy, right_justified),
             max_chars: max_chars.max(3),
@@ -149,7 +144,7 @@ pub struct CurrentLayout {
 
 impl CurrentLayout {
     /// Create a new CurrentLayout widget
-    pub fn new(style: &TextStyle) -> Self {
+    pub fn new(style: TextStyle) -> Self {
         Self {
             inner: Text::new("", style, false, false),
         }

--- a/crates/penrose_ui/src/bar/widgets/simple.rs
+++ b/crates/penrose_ui/src/bar/widgets/simple.rs
@@ -25,11 +25,11 @@ impl RootWindowName {
 }
 
 impl<X: XConn> Widget<X> for RootWindowName {
-    fn draw(&mut self, ctx: &mut Context, s: usize, f: bool, w: f64, h: f64) -> Result<()> {
+    fn draw(&mut self, ctx: &mut Context<'_>, s: usize, f: bool, w: u32, h: u32) -> Result<()> {
         Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, h: u32) -> Result<(u32, u32)> {
         Widget::<X>::current_extent(&mut self.inner, ctx, h)
     }
 
@@ -92,15 +92,15 @@ impl ActiveWindowName {
 }
 
 impl<X: XConn> Widget<X> for ActiveWindowName {
-    fn draw(&mut self, ctx: &mut Context, s: usize, focused: bool, w: f64, h: f64) -> Result<()> {
-        if focused {
-            Widget::<X>::draw(&mut self.inner, ctx, s, focused, w, h)
+    fn draw(&mut self, ctx: &mut Context<'_>, s: usize, f: bool, w: u32, h: u32) -> Result<()> {
+        if f {
+            Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
         } else {
             Ok(())
         }
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, h: u32) -> Result<(u32, u32)> {
         Widget::<X>::current_extent(&mut self.inner, ctx, h)
     }
 
@@ -157,11 +157,11 @@ impl CurrentLayout {
 }
 
 impl<X: XConn> Widget<X> for CurrentLayout {
-    fn draw(&mut self, ctx: &mut Context, s: usize, f: bool, w: f64, h: f64) -> Result<()> {
+    fn draw(&mut self, ctx: &mut Context<'_>, s: usize, f: bool, w: u32, h: u32) -> Result<()> {
         Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, h: u32) -> Result<(u32, u32)> {
         Widget::<X>::current_extent(&mut self.inner, ctx, h)
     }
 

--- a/crates/penrose_ui/src/bar/widgets/sys.rs
+++ b/crates/penrose_ui/src/bar/widgets/sys.rs
@@ -7,7 +7,7 @@ use std::fs;
 ///
 /// If the given battery name is not found on this system, this widget will
 /// render as an empty string.
-pub fn battery_summary(bat: &'static str, style: &TextStyle) -> RefreshText {
+pub fn battery_summary(bat: &'static str, style: TextStyle) -> RefreshText {
     RefreshText::new(style, move || battery_text(bat).unwrap_or_default())
 }
 
@@ -44,7 +44,7 @@ fn read_sys_file(bat: &str, fname: &str) -> Option<String> {
 /// Display the current date and time in YYYY-MM-DD HH:MM format
 ///
 /// This widget shells out to the `date` tool to generate its output
-pub fn current_date_and_time(style: &TextStyle) -> RefreshText {
+pub fn current_date_and_time(style: TextStyle) -> RefreshText {
     RefreshText::new(style, || {
         spawn_for_output_with_args("date", &["+%F %R"])
             .unwrap_or_default()
@@ -55,7 +55,7 @@ pub fn current_date_and_time(style: &TextStyle) -> RefreshText {
 
 /// Display the ESSID currently connected to and the signal quality as
 /// a percentage.
-pub fn wifi_network(style: &TextStyle) -> RefreshText {
+pub fn wifi_network(style: TextStyle) -> RefreshText {
     RefreshText::new(style, move || wifi_text().unwrap_or_default())
 }
 
@@ -98,7 +98,7 @@ fn signal_quality(interface: &str) -> Option<String> {
 }
 
 /// Display the current volume level as reported by `amixer`
-pub fn amixer_volume(channel: &'static str, style: &TextStyle) -> RefreshText {
+pub fn amixer_volume(channel: &'static str, style: TextStyle) -> RefreshText {
     RefreshText::new(style, move || amixer_text(channel).unwrap_or_default())
 }
 

--- a/crates/penrose_ui/src/bar/widgets/workspaces.rs
+++ b/crates/penrose_ui/src/bar/widgets/workspaces.rs
@@ -6,17 +6,18 @@ use crate::{
 };
 use penrose::{
     core::{ClientSpace, State},
+    pure::geometry::Rect,
     x::XConn,
     Color,
 };
 
-const PADDING: f64 = 3.0;
+const PADDING: u32 = 3;
 
 #[derive(Clone, Debug, PartialEq)]
 struct WsMeta {
     tag: String,
     occupied: bool,
-    extent: (f64, f64),
+    extent: (u32, u32),
 }
 
 impl WsMeta {
@@ -34,7 +35,7 @@ impl From<&ClientSpace> for WsMeta {
         Self {
             tag: w.tag().to_owned(),
             occupied: !w.is_empty(),
-            extent: (0.0, 0.0),
+            extent: (0, 0),
         }
     }
 }
@@ -57,8 +58,8 @@ pub struct Workspaces {
     workspaces: Vec<WsMeta>,
     focused_ws: Vec<String>, // focused ws per screen
     font: String,
-    point_size: i32,
-    extent: Option<(f64, f64)>,
+    point_size: u8,
+    extent: Option<(u32, u32)>,
     fg_1: Color,
     fg_2: Color,
     bg_1: Color,
@@ -126,7 +127,7 @@ impl Workspaces {
         screen: usize,
         screen_has_focus: bool,
         occupied: bool,
-    ) -> (&Color, Option<&Color>) {
+    ) -> (Color, Color) {
         let focused_on_this_screen = match &self.focused_ws.get(screen) {
             &Some(focused_tag) => tag == focused_tag,
             None => false,
@@ -136,21 +137,17 @@ impl Workspaces {
         let focused_other = focused && !focused_on_this_screen;
 
         if focused_on_this_screen && screen_has_focus {
-            let fg = if occupied { &self.fg_1 } else { &self.fg_2 };
+            let fg = if occupied { self.fg_1 } else { self.fg_2 };
 
-            (fg, Some(&self.bg_1))
+            (fg, self.bg_1)
         } else if focused {
-            let fg = if focused_other {
-                &self.bg_1
-            } else {
-                &self.fg_1
-            };
+            let fg = if focused_other { self.bg_1 } else { self.fg_1 };
 
-            (fg, Some(&self.fg_2))
+            (fg, self.fg_2)
         } else {
-            let fg = if occupied { &self.fg_1 } else { &self.fg_2 };
+            let fg = if occupied { self.fg_1 } else { self.fg_2 };
 
-            (fg, None)
+            (fg, self.bg_2)
         }
     }
 }
@@ -158,28 +155,21 @@ impl Workspaces {
 impl<X: XConn> Widget<X> for Workspaces {
     fn draw(
         &mut self,
-        ctx: &mut Context,
+        ctx: &mut Context<'_>,
         screen: usize,
         screen_has_focus: bool,
-        w: f64,
-        h: f64,
+        w: u32,
+        h: u32,
     ) -> Result<()> {
-        ctx.color(&self.bg_2);
-        ctx.rectangle(0.0, 0.0, w, h)?;
-        ctx.font(&self.font, self.point_size)?;
-        ctx.translate(PADDING, 0.0);
+        ctx.fill_rect(Rect::new(0, 0, w, h), self.bg_2)?;
+        ctx.translate(PADDING as i32, 0);
         let (_, eh) = <Self as Widget<X>>::current_extent(self, ctx, h)?;
 
         for ws in self.workspaces.iter() {
             let (fg, bg) = self.ws_colors(&ws.tag, screen, screen_has_focus, ws.occupied);
-            if let Some(c) = bg {
-                ctx.color(c);
-                ctx.rectangle(0.0, 0.0, ws.extent.0, h)?;
-            }
-
-            ctx.color(fg);
-            ctx.text(&ws.tag, h - eh, (PADDING, PADDING))?;
-            ctx.translate(ws.extent.0, 0.0);
+            ctx.fill_rect(Rect::new(0, 0, ws.extent.0, h), bg)?;
+            ctx.draw_text(&ws.tag, h - eh, (PADDING, PADDING), fg)?;
+            ctx.translate(ws.extent.0 as i32, 0);
         }
 
         self.require_draw = false;
@@ -187,18 +177,17 @@ impl<X: XConn> Widget<X> for Workspaces {
         Ok(())
     }
 
-    fn current_extent(&mut self, ctx: &mut Context, _h: f64) -> Result<(f64, f64)> {
+    fn current_extent(&mut self, ctx: &mut Context<'_>, _h: u32) -> Result<(u32, u32)> {
         match self.extent {
             Some(extent) => Ok(extent),
             None => {
-                let mut total = 0.0;
-                let mut h_max = 0.0;
+                let mut total = 0;
+                let mut h_max = 0;
                 for ws in self.workspaces.iter_mut() {
-                    ctx.font(&self.font, self.point_size)?;
                     let (w, h) = ctx.text_extent(&ws.tag)?;
-                    total += w + PADDING + PADDING;
+                    total += w + 2 * PADDING;
                     h_max = if h > h_max { h } else { h_max };
-                    ws.extent = (w + PADDING + PADDING, h);
+                    ws.extent = (w + 2 * PADDING, h);
                 }
 
                 let ext = (total + PADDING, h_max);

--- a/crates/penrose_ui/src/bar/widgets/workspaces.rs
+++ b/crates/penrose_ui/src/bar/widgets/workspaces.rs
@@ -57,8 +57,6 @@ fn focused_workspaces<X: XConn>(state: &State<X>) -> Vec<String> {
 pub struct Workspaces {
     workspaces: Vec<WsMeta>,
     focused_ws: Vec<String>, // focused ws per screen
-    font: String,
-    point_size: u8,
     extent: Option<(u32, u32)>,
     fg_1: Color,
     fg_2: Color,
@@ -69,12 +67,10 @@ pub struct Workspaces {
 
 impl Workspaces {
     /// Construct a new WorkspaceWidget
-    pub fn new(style: &TextStyle, highlight: impl Into<Color>, empty_fg: impl Into<Color>) -> Self {
+    pub fn new(style: TextStyle, highlight: impl Into<Color>, empty_fg: impl Into<Color>) -> Self {
         Self {
             workspaces: vec![],
             focused_ws: vec![], // set in startup hook
-            font: style.font.clone(),
-            point_size: style.point_size,
             extent: None,
             fg_1: style.fg,
             fg_2: empty_fg.into(),

--- a/crates/penrose_ui/src/core/fontset.rs
+++ b/crates/penrose_ui/src/core/fontset.rs
@@ -1,0 +1,249 @@
+use crate::{core::SCREEN, Error, Result};
+use fontconfig_sys::{
+    constants::{FC_CHARSET, FC_SCALABLE},
+    FcCharSetAddChar, FcCharSetCreate, FcCharSetDestroy, FcConfig, FcConfigSubstitute,
+    FcDefaultSubstitute, FcMatchPattern, FcPatternAddBool, FcPatternAddCharSet, FcPatternDestroy,
+    FcPatternDuplicate,
+};
+use std::{
+    alloc::{alloc, handle_alloc_error, Layout},
+    collections::HashMap,
+    ffi::CString,
+};
+use x11::{
+    xft::{
+        FcPattern, FcResult, XftCharExists, XftFont, XftFontClose, XftFontMatch, XftFontOpenName,
+        XftFontOpenPattern, XftNameParse, XftTextExtentsUtf8,
+    },
+    xlib::Display,
+    xrender::XGlyphInfo,
+};
+
+#[derive(Debug)]
+pub(crate) struct Fontset {
+    dpy: *mut Display,
+    primary: Font,
+    fallback: Vec<Font>,
+    char_cache: HashMap<char, FontMatch>,
+}
+
+impl Fontset {
+    pub(crate) fn try_new(dpy: *mut Display, fnt: &str) -> Result<Self> {
+        Ok(Self {
+            dpy,
+            primary: Font::try_new_from_name(dpy, fnt)?,
+            fallback: Default::default(),
+            char_cache: Default::default(),
+        })
+    }
+
+    // Find boundaries where we need to change the font we are using for rendering utf8
+    // characters from the given input.
+    pub(crate) fn per_font_chunks<'a>(&mut self, txt: &'a str) -> Vec<(&'a str, FontMatch)> {
+        let mut char_indices = txt.char_indices();
+        let mut chunks = Vec::new();
+        let mut last_split = 0;
+        let mut chunk: &str;
+        let mut rest = txt;
+
+        let mut cur_fm = match char_indices.next() {
+            Some((_, c)) => self.fnt_for_char(c),
+            None => return chunks, // empty string: no chunks
+        };
+
+        for (i, c) in char_indices {
+            let fm = self.fnt_for_char(c);
+            if fm != cur_fm {
+                (chunk, rest) = rest.split_at(i - last_split);
+                chunks.push((chunk, cur_fm));
+                cur_fm = fm;
+                last_split = i;
+            }
+        }
+
+        if !rest.is_empty() {
+            chunks.push((rest, cur_fm));
+        }
+
+        chunks
+    }
+
+    pub(crate) fn fnt(&self, fm: FontMatch) -> &Font {
+        match fm {
+            FontMatch::Primary => &self.primary,
+            FontMatch::Fallback(n) => &self.fallback[n],
+        }
+    }
+
+    fn fnt_for_char(&mut self, c: char) -> FontMatch {
+        if let Some(fm) = self.char_cache.get(&c) {
+            return *fm;
+        }
+
+        if self.primary.contains_char(self.dpy, c) {
+            self.char_cache.insert(c, FontMatch::Primary);
+            return FontMatch::Primary;
+        }
+
+        for (i, fnt) in self.fallback.iter().enumerate() {
+            if fnt.contains_char(self.dpy, c) {
+                self.char_cache.insert(c, FontMatch::Fallback(i));
+                return FontMatch::Fallback(i);
+            }
+        }
+
+        let fallback = match self.primary.fallback_for_char(self.dpy, c) {
+            Ok(fnt) => {
+                self.fallback.push(fnt);
+                FontMatch::Fallback(self.fallback.len() - 1)
+            }
+
+            Err(e) => {
+                // TODO: add tracing to this crate
+                println!("ERROR: {e}");
+                FontMatch::Primary
+            }
+        };
+
+        self.char_cache.insert(c, fallback);
+
+        fallback
+    }
+}
+
+impl Drop for Fontset {
+    fn drop(&mut self) {
+        // SAFETY: the Display we have a pointer to is freed by the parent draw
+        unsafe {
+            XftFontClose(self.dpy, self.primary.xfont);
+            for f in self.fallback.drain(0..) {
+                XftFontClose(self.dpy, f.xfont);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum FontMatch {
+    Primary,
+    Fallback(usize),
+}
+
+// Fonts contain a resource that requires a Display to free on Drop so they
+// are owned by their parent Draw and cleaned up when the Draw is dropped
+//
+// https://man.archlinux.org/man/extra/libxft/XftFontMatch.3.en
+// https://refspecs.linuxfoundation.org/fontconfig-2.6.0/index.html
+#[derive(Debug)]
+pub(crate) struct Font {
+    pub(crate) h: u32,
+    pub(crate) xfont: *mut XftFont,
+    pattern: *mut FcPattern,
+}
+
+impl Font {
+    fn try_new_from_name(dpy: *mut Display, name: &str) -> Result<Self> {
+        let (xfont, pattern, h) = unsafe {
+            let c_name = CString::new(name)?;
+            let xfont = XftFontOpenName(dpy, SCREEN, c_name.as_ptr());
+            if xfont.is_null() {
+                return Err(Error::UnableToOpenFont(name.to_string()));
+            }
+
+            let pattern = XftNameParse(c_name.as_ptr());
+            if pattern.is_null() {
+                XftFontClose(dpy, xfont);
+                return Err(Error::UnableToParseFontPattern(name.to_string()));
+            }
+
+            let h = (*xfont).ascent + (*xfont).descent;
+
+            (xfont, pattern, h as u32)
+        };
+
+        Ok(Font { xfont, pattern, h })
+    }
+
+    fn try_new_from_pattern(dpy: *mut Display, pattern: *mut FcPattern) -> Result<Self> {
+        let (xfont, h) = unsafe {
+            let xfont = XftFontOpenPattern(dpy, pattern);
+            if xfont.is_null() {
+                return Err(Error::UnableToOpenFontPattern);
+            }
+
+            let h = (*xfont).ascent + (*xfont).descent;
+
+            (xfont, h as u32)
+        };
+
+        Ok(Font { xfont, pattern, h })
+    }
+
+    fn contains_char(&self, dpy: *mut Display, c: char) -> bool {
+        unsafe { XftCharExists(dpy, self.xfont, c as u32) == 1 }
+    }
+
+    pub(crate) fn get_exts(&self, dpy: *mut Display, txt: &str) -> Result<(u32, u32)> {
+        unsafe {
+            // https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+            let layout = Layout::new::<XGlyphInfo>();
+            let ptr = alloc(layout);
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            let ext = ptr as *mut XGlyphInfo;
+
+            let c_str = CString::new(txt)?;
+            XftTextExtentsUtf8(
+                dpy,
+                self.xfont,
+                c_str.as_ptr() as *mut u8,
+                c_str.as_bytes().len() as i32,
+                ext,
+            );
+
+            Ok(((*ext).xOff as u32, self.h))
+        }
+    }
+
+    /// Find a font that can handle a given character using fontconfig and this font's pattern
+    fn fallback_for_char(&self, dpy: *mut Display, c: char) -> Result<Self> {
+        let pat = self.fc_font_match(dpy, c)?;
+
+        Font::try_new_from_pattern(dpy, pat)
+    }
+
+    fn fc_font_match(&self, dpy: *mut Display, c: char) -> Result<*mut FcPattern> {
+        unsafe {
+            let charset = FcCharSetCreate();
+            FcCharSetAddChar(charset, c as u32);
+
+            let pat = FcPatternDuplicate(self.pattern as *const _);
+            FcPatternAddCharSet(pat, FC_CHARSET.as_ptr(), charset);
+            FcPatternAddBool(pat, FC_SCALABLE.as_ptr(), 1); // FcTrue=1
+
+            FcConfigSubstitute(std::ptr::null::<FcConfig>() as *mut _, pat, FcMatchPattern);
+            FcDefaultSubstitute(pat);
+
+            // https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+            let layout = Layout::new::<FcResult>();
+            let ptr = alloc(layout);
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            let res = ptr as *mut FcResult;
+
+            // Passing the pointer from fontconfig_sys to x11 here
+            let font_match = XftFontMatch(dpy, SCREEN, pat as *const _, res);
+
+            FcCharSetDestroy(charset);
+            FcPatternDestroy(pat);
+
+            if font_match.is_null() {
+                Err(Error::NoFallbackFontForChar(c))
+            } else {
+                Ok(font_match as *mut _)
+            }
+        }
+    }
+}

--- a/crates/penrose_ui/src/core/mod.rs
+++ b/crates/penrose_ui/src/core/mod.rs
@@ -28,13 +28,9 @@ use fontset::Fontset;
 
 pub(crate) const SCREEN: i32 = 0;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// A set of styling options for a text string
 pub struct TextStyle {
-    /// Font name to use for rendering
-    pub font: String,
-    /// Point size to render the font at
-    pub point_size: u8,
     /// Foreground color in 0xRRGGBB format
     pub fg: Color,
     /// Optional background color in 0xRRGGBB format (default to current background if None)

--- a/crates/penrose_ui/src/core/mod.rs
+++ b/crates/penrose_ui/src/core/mod.rs
@@ -1,46 +1,53 @@
 //! The core [`Draw`] and [`Context`] structs for rendering UI elements.
 use crate::{Error, Result};
-use cairo::{Matrix, Operator, XCBConnection, XCBDrawable, XCBSurface, XCBVisualType};
-use pango::{EllipsizeMode, FontDescription, SCALE};
-use pangocairo::functions::{create_layout, show_layout};
 use penrose::{
     pure::geometry::Rect,
     x::{WinType, XConn},
-    x11rb::XcbConn,
+    x11rb::RustConn,
     Color, Xid,
 };
-use std::collections::HashMap;
+use std::{
+    alloc::{alloc, dealloc, handle_alloc_error, Layout},
+    cmp::max,
+    collections::HashMap,
+    ffi::CString,
+};
 use tracing::{debug, info};
-use x11rb::{connection::Connection, protocol::xproto::Screen};
+use x11::{
+    xft::{XftColor, XftColorAllocName, XftDrawCreate, XftDrawStringUtf8},
+    xlib::{
+        CapButt, Display, Drawable, False, JoinMiter, LineSolid, Window, XCopyArea, XCreateGC,
+        XCreatePixmap, XDefaultColormap, XDefaultDepth, XDefaultVisual, XDrawRectangle,
+        XFillRectangle, XFreeGC, XFreePixmap, XOpenDisplay, XSetForeground, XSetLineAttributes,
+        XSync, GC,
+    },
+};
 
-// A rust version of XCB's `xcb_visualtype_t` struct for FFI.
-// Taken from https://github.com/psychon/x11rb/blob/c3894c092101a16cedf4c45e487652946a3c4284/cairo-example/src/main.rs
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-struct XcbVisualtypeT {
-    pub visual_id: u32,
-    pub class: u8,
-    pub bits_per_rgb_value: u8,
-    pub colormap_entries: u16,
-    pub red_mask: u32,
-    pub green_mask: u32,
-    pub blue_mask: u32,
-    pub pad0: [u8; 4],
-}
+mod fontset;
+use fontset::Fontset;
 
-#[derive(Clone, Debug, PartialEq)]
+pub(crate) const SCREEN: i32 = 0;
+
+#[derive(Debug, Clone, PartialEq)]
 /// A set of styling options for a text string
 pub struct TextStyle {
     /// Font name to use for rendering
     pub font: String,
     /// Point size to render the font at
-    pub point_size: i32,
+    pub point_size: u8,
     /// Foreground color in 0xRRGGBB format
     pub fg: Color,
     /// Optional background color in 0xRRGGBB format (default to current background if None)
     pub bg: Option<Color>,
     /// Pixel padding around this piece of text
-    pub padding: (f64, f64),
+    pub padding: (u32, u32),
+}
+
+#[derive(Debug)]
+struct Surface {
+    drawable: Drawable,
+    gc: GC,
+    r: Rect,
 }
 
 /// Your application should create a single [`Draw`] struct to manage the windows and surfaces it
@@ -49,124 +56,105 @@ pub struct TextStyle {
 #[derive(Debug)]
 pub struct Draw {
     /// The underlying [`XConn`] implementation used to communicate with the X server
-    pub conn: XcbConn,
-    fonts: HashMap<String, FontDescription>,
-    surfaces: HashMap<Xid, XCBSurface>,
+    pub conn: RustConn,
+    dpy: *mut Display,
+    fs: Fontset,
+    bg: Color,
+    surfaces: HashMap<Xid, Surface>,
+    colors: HashMap<Color, XColor>,
+}
+
+impl Drop for Draw {
+    fn drop(&mut self) {
+        unsafe {
+            for (_, s) in self.surfaces.drain() {
+                XFreePixmap(self.dpy, s.drawable);
+                XFreeGC(self.dpy, s.gc);
+            }
+        }
+    }
 }
 
 impl Draw {
-    /// Construct a new `Draw` instance backed with an [`XcbConn`].
+    /// Construct a new `Draw` instance backed with an [`RustConn`].
     ///
     /// This method will error if it is unable to establish a connection with the X server.
-    pub fn new() -> Result<Self> {
+    pub fn new(font: &str, point_size: u8, bg: Color) -> Result<Self> {
+        let conn = RustConn::new()?;
+        let dpy = unsafe { XOpenDisplay(std::ptr::null()) };
+        let mut colors = HashMap::new();
+        colors.insert(bg, XColor::try_new(dpy, &bg)?);
+
         Ok(Self {
-            conn: XcbConn::new()?,
-            fonts: HashMap::new(),
+            conn,
+            dpy,
+            fs: Fontset::try_new(dpy, &format!("{font}:size={point_size}"))?,
             surfaces: HashMap::new(),
+            bg,
+            colors,
         })
     }
 
-    /// Create a new X window and initialise a cairo surface for drawing.
+    /// Create a new X window with an initialised surface for drawing
     pub fn new_window(&mut self, ty: WinType, r: Rect, managed: bool) -> Result<Xid> {
         info!(?ty, ?r, %managed, "creating new window");
         let id = self.conn.create_window(ty, r, managed)?;
 
-        debug!("getting screen details");
-        let screen = &self.conn.connection().setup().roots[0];
+        debug!("initialising graphics context and pixmap");
+        let root = *self.conn.root() as Window;
+        let (drawable, gc) = unsafe {
+            let depth = XDefaultDepth(self.dpy, SCREEN) as u32;
+            let drawable = XCreatePixmap(self.dpy, root, r.w, r.h, depth);
+            let gc = XCreateGC(self.dpy, root, 0, std::ptr::null_mut());
+            XSetLineAttributes(self.dpy, gc, 1, LineSolid, CapButt, JoinMiter);
 
-        debug!("creating surface");
-        let surface = self.surface(*id, screen, r.w as i32, r.h as i32)?;
-        self.surfaces.insert(id, surface);
+            (drawable, gc)
+        };
+
+        self.surfaces.insert(id, Surface { r, gc, drawable });
 
         Ok(id)
     }
 
-    fn surface(&self, id: u32, screen: &Screen, w: i32, h: i32) -> Result<XCBSurface> {
-        let mut visual = self.find_xcb_visualtype(screen.root_visual);
-
-        let surface = unsafe {
-            debug!(%id, "calling cairo::XCBSurface::create");
-            cairo::XCBSurface::create(
-                &XCBConnection::from_raw_none(self.conn.connection().get_raw_xcb_connection() as _),
-                &XCBDrawable(id),
-                &XCBVisualType::from_raw_none(&mut visual as *mut _ as _),
-                w,
-                h,
-            )?
-        };
-
-        debug!(%id, "setting surface size");
-        surface.set_size(w, h)?;
-
-        Ok(surface)
-    }
-
-    fn find_xcb_visualtype(&self, visual_id: u32) -> XcbVisualtypeT {
-        for root in &self.conn.connection().setup().roots {
-            for depth in &root.allowed_depths {
-                for visual in &depth.visuals {
-                    if visual.visual_id == visual_id {
-                        return XcbVisualtypeT {
-                            visual_id: visual.visual_id,
-                            class: visual.class.into(),
-                            bits_per_rgb_value: visual.bits_per_rgb_value,
-                            colormap_entries: visual.colormap_entries,
-                            red_mask: visual.red_mask,
-                            green_mask: visual.green_mask,
-                            blue_mask: visual.blue_mask,
-                            pad0: [0; 4],
-                        };
-                    }
-                }
-            }
-        }
-
-        panic!("unable to find XCB visual type")
-    }
-
     /// Register a new font by name in the font cache so it can be used in a drawing [`Context`].
-    pub fn register_font(&mut self, font_name: &str) {
-        let description = FontDescription::from_string(font_name);
-        self.fonts.insert(font_name.into(), description);
+    pub fn set_font(&mut self, font: &str) -> Result<()> {
+        self.fs = Fontset::try_new(self.dpy, font)?;
+
+        Ok(())
     }
 
     /// Retrieve the drawing [`Context`] for the given window [`Xid`].
     ///
     /// This method will error if the requested id does not already have an initialised surface.
     /// See the [`new_window`] method for details.
-    pub fn context_for(&self, id: Xid) -> Result<Context> {
-        let ctx = cairo::Context::new(
-            self.surfaces
-                .get(&id)
-                .ok_or(Error::UnintialisedSurface { id })?,
-        )?;
+    pub fn context_for(&mut self, id: Xid) -> Result<Context<'_>> {
+        let s = self
+            .surfaces
+            .get(&id)
+            .ok_or(Error::UnintialisedSurface { id })?;
 
         Ok(Context {
-            ctx,
-            font: None,
-            fonts: self.fonts.clone(),
-        })
-    }
-
-    /// Construct a disposable context of the specified dimensions without requiring a
-    /// window [`Xid`].
-    pub fn temp_context(&self, w: i32, h: i32) -> Result<Context> {
-        let screen = &self.conn.connection().setup().roots[0];
-        let surface = self.surface(*self.conn.root(), screen, w, h)?;
-        let surface = surface.create_similar(cairo::Content::Color, w, h)?;
-        let ctx = cairo::Context::new(&surface)?;
-
-        Ok(Context {
-            ctx,
-            font: None,
-            fonts: self.fonts.clone(),
+            id: *id as u64,
+            dx: 0,
+            dy: 0,
+            dpy: self.dpy,
+            s,
+            bg: self.bg,
+            fs: &mut self.fs,
+            colors: &mut self.colors,
         })
     }
 
     /// Flush any pending requests to the X server and map the specifed window to the screen.
     pub fn flush(&self, id: Xid) -> Result<()> {
         if let Some(s) = self.surfaces.get(&id) {
-            s.flush()
+            let Rect { x, y, w, h } = s.r;
+            let (x, y) = (x as i32, y as i32);
+
+            unsafe {
+                XCopyArea(self.dpy, s.drawable, *id as u64, s.gc, x, y, w, h, x, y);
+                XSync(self.dpy, False);
+            }
         };
 
         self.conn.map(id)?;
@@ -176,118 +164,200 @@ impl Draw {
     }
 }
 
-/// A minimal drawing context for rendering text based UI elements to a cairo surface.
-#[derive(Clone, Debug)]
-pub struct Context {
-    ctx: cairo::Context,
-    font: Option<FontDescription>,
-    fonts: HashMap<String, FontDescription>,
+/// A minimal drawing context for rendering text based UI elements
+#[derive(Debug)]
+pub struct Context<'a> {
+    id: u64,
+    dx: i32,
+    dy: i32,
+    dpy: *mut Display,
+    s: &'a Surface,
+    bg: Color,
+    fs: &'a mut Fontset,
+    colors: &'a mut HashMap<Color, XColor>,
 }
 
-impl Context {
-    /// Set the current font by name.
-    ///
-    /// This method will error if the font has not previously been registered in the parent
-    /// [`Draw`] struct.
-    pub fn font(&mut self, font_name: &str, point_size: i32) -> Result<()> {
-        let mut font = self
-            .fonts
-            .get_mut(font_name)
-            .ok_or_else(|| Error::UnknownFont {
-                font: font_name.into(),
-            })?
-            .clone();
-
-        font.set_size(point_size * SCALE);
-        self.font = Some(font);
-
-        Ok(())
-    }
-
-    /// Set the active color for following draw operations.
-    pub fn color(&mut self, color: &Color) {
-        let (r, g, b, a) = color.rgba();
-        self.ctx.set_source_rgba(r, g, b, a);
-    }
-
-    /// Clear the underlying [`cairo::Context`].
+impl<'a> Context<'a> {
+    /// Clear the underlying surface, restoring it to the background color.
     pub fn clear(&mut self) -> Result<()> {
-        self.ctx.save()?;
-        self.ctx.set_operator(Operator::Clear);
-        self.ctx.paint()?;
-        self.ctx.restore()?;
+        self.fill_rect(Rect::new(0, 0, self.s.r.w, self.s.r.h), self.bg)
+    }
+
+    /// Offset future drawing operations by an additional (dx, dy)
+    pub fn translate(&mut self, dx: i32, dy: i32) {
+        self.dx += dx;
+        self.dy += dy;
+    }
+
+    /// Set future drawing operations to apply from the origin.
+    pub fn reset_offset(&mut self) {
+        self.dx = 0;
+        self.dy = 0;
+    }
+
+    /// Set an absolute x offset for future drawing operations.
+    pub fn set_x_offset(&mut self, x: i32) {
+        self.dx = x;
+    }
+
+    /// Set an absolute y offset for future drawing operations.
+    pub fn set_y_offset(&mut self, y: i32) {
+        self.dy = y;
+    }
+
+    fn get_or_try_init_xcolor(&mut self, c: Color) -> Result<*mut XftColor> {
+        Ok(self
+            .colors
+            .entry(c)
+            .or_insert(XColor::try_new(self.dpy, &c)?)
+            .0)
+    }
+
+    /// Render a rectangular border using the supplied color.
+    pub fn draw_rect(&mut self, Rect { x, y, w, h }: Rect, color: Color) -> Result<()> {
+        let xcol = self.get_or_try_init_xcolor(color)?;
+        let (x, y) = (x as i32, y as i32);
+
+        unsafe {
+            XSetForeground(self.dpy, self.s.gc, (*xcol).pixel);
+            XDrawRectangle(self.dpy, self.s.drawable, self.s.gc, x, y, w, h);
+        }
 
         Ok(())
     }
 
-    /// Translate the underlying [`cairo::Context`] by a specified offset
-    pub fn translate(&self, dx: f64, dy: f64) {
-        self.ctx.translate(dx, dy)
-    }
+    /// Render a filled rectangle using the supplied color.
+    pub fn fill_rect(&mut self, Rect { x, y, w, h }: Rect, color: Color) -> Result<()> {
+        let xcol = self.get_or_try_init_xcolor(color)?;
+        let (x, y) = (x as i32, y as i32);
 
-    /// Set the x offset of the underlying [`cairo::Context`] without modifying the
-    /// current y position.
-    pub fn set_x_offset(&self, x: f64) {
-        let (_, y_offset) = self.ctx.matrix().transform_point(0.0, 0.0);
-        self.ctx.set_matrix(Matrix::identity());
-        self.ctx.translate(x, y_offset);
-    }
-
-    /// Set the y offset of the underlying [`cairo::Context`] without modifying the
-    /// current x position.
-    pub fn set_y_offset(&self, y: f64) {
-        let (x_offset, _) = self.ctx.matrix().transform_point(0.0, 0.0);
-        self.ctx.set_matrix(Matrix::identity());
-        self.ctx.translate(x_offset, y);
-    }
-
-    /// Fill the specified area with the currently active color.
-    pub fn rectangle(&self, x: f64, y: f64, w: f64, h: f64) -> Result<()> {
-        self.ctx.rectangle(x, y, w, h);
-        self.ctx.fill()?;
+        unsafe {
+            XSetForeground(self.dpy, self.s.gc, (*xcol).pixel);
+            XFillRectangle(self.dpy, self.s.drawable, self.s.gc, x, y, w, h);
+        }
 
         Ok(())
     }
 
-    /// Draw the specified text using the currently active font and color.
-    ///
-    /// Returns the width and height of the area taken up by the text.
-    pub fn text(&self, txt: &str, h_offset: f64, padding: (f64, f64)) -> Result<(f64, f64)> {
-        let layout = create_layout(&self.ctx);
-        if let Some(ref font) = self.font {
-            layout.set_font_description(Some(font));
+    // TODO: Need to bounds checks
+    // https://keithp.com/~keithp/talks/xtc2001/xft.pdf
+    // https://keithp.com/~keithp/render/Xft.tutorial
+    //
+    /// Render the provided text at the current context offset using the supplied color.
+    pub fn draw_text(
+        &mut self,
+        txt: &str,
+        h_offset: u32,
+        padding: (u32, u32),
+        c: Color,
+    ) -> Result<(u32, u32)> {
+        let d = unsafe {
+            XftDrawCreate(
+                self.dpy,
+                self.s.drawable,
+                XDefaultVisual(self.dpy, SCREEN),
+                XDefaultColormap(self.dpy, SCREEN),
+            )
+        };
+
+        let (lpad, rpad) = (padding.0 as i32, padding.1);
+        let (mut x, y) = (lpad + self.dx, self.dy + h_offset as i32);
+        let (mut total_w, mut total_h) = (x as u32, 0);
+        let xcol = self.get_or_try_init_xcolor(c)?;
+
+        for (chunk, fm) in self.fs.per_font_chunks(txt).into_iter() {
+            let fnt = self.fs.fnt(fm);
+            let (chunk_w, chunk_h) = fnt.get_exts(self.dpy, chunk)?;
+
+            // SAFETY: fnt pointer is non-null
+            let chunk_y = unsafe { y + (h_offset + chunk_h) as i32 / 2 + (*fnt.xfont).ascent };
+            let c_str = CString::new(chunk)?;
+
+            unsafe {
+                XftDrawStringUtf8(
+                    d,
+                    xcol,
+                    fnt.xfont,
+                    x,
+                    chunk_y,
+                    c_str.as_ptr() as *mut _,
+                    c_str.as_bytes().len() as i32,
+                );
+            }
+
+            x += chunk_w as i32;
+            total_w += chunk_w;
+            total_h = max(total_h, chunk_h);
         }
 
-        layout.set_text(txt);
-        layout.set_ellipsize(EllipsizeMode::End);
-
-        let (w, h) = layout.pixel_size();
-        let (l, r) = padding;
-        self.ctx.translate(l, h_offset);
-        show_layout(&self.ctx, &layout);
-        self.ctx.translate(-l, -h_offset);
-
-        let width = w as f64 + l + r;
-        let height = h as f64;
-
-        Ok((width, height))
+        Ok((total_w + rpad, total_h))
     }
 
-    /// Determine the width and height required to render a specific piece of text
-    /// using the current font without rendering it to the underlying [`cairo::Context`].
-    pub fn text_extent(&self, s: &str) -> Result<(f64, f64)> {
-        let layout = create_layout(&self.ctx);
-        if let Some(ref font) = self.font {
-            layout.set_font_description(Some(font));
+    /// Determine the width and height taken up by a given string in pixels.
+    pub fn text_extent(&mut self, txt: &str) -> Result<(u32, u32)> {
+        let (mut w, mut h) = (0, 0);
+        for (chunk, fm) in self.fs.per_font_chunks(txt) {
+            let (cw, ch) = self.fs.fnt(fm).get_exts(self.dpy, chunk)?;
+            w += cw;
+            h = max(h, ch);
         }
-        layout.set_text(s);
-        let (w, h) = layout.pixel_size();
 
-        Ok((w as f64, h as f64))
+        Ok((w, h))
     }
 
     /// Flush pending requests to the X server.
     pub fn flush(&self) {
-        self.ctx.target().flush();
+        let Surface {
+            r: Rect { w, h, .. },
+            gc,
+            drawable,
+        } = *self.s;
+
+        unsafe {
+            XCopyArea(self.dpy, drawable, self.id, gc, 0, 0, w, h, 0, 0);
+            XSync(self.dpy, False);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct XColor(*mut XftColor);
+
+impl Drop for XColor {
+    fn drop(&mut self) {
+        let layout = Layout::new::<XftColor>();
+        unsafe { dealloc(self.0 as *mut u8, layout) }
+    }
+}
+
+impl XColor {
+    fn try_new(dpy: *mut Display, c: &Color) -> Result<Self> {
+        let inner = unsafe { try_xftcolor_from_name(dpy, &c.as_rgb_hex_string())? };
+
+        Ok(Self(inner))
+    }
+}
+
+unsafe fn try_xftcolor_from_name(dpy: *mut Display, color: &str) -> Result<*mut XftColor> {
+    // https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc
+    let layout = Layout::new::<XftColor>();
+    let ptr = alloc(layout);
+    if ptr.is_null() {
+        handle_alloc_error(layout);
+    }
+
+    let c_name = CString::new(color)?;
+    let res = XftColorAllocName(
+        dpy,
+        XDefaultVisual(dpy, SCREEN),
+        XDefaultColormap(dpy, SCREEN),
+        c_name.as_ptr(),
+        ptr as *mut XftColor,
+    );
+
+    if res == 0 {
+        Err(Error::UnableToAllocateColor)
+    } else {
+        Ok(ptr as *mut XftColor)
     }
 }

--- a/crates/penrose_ui/src/core/mod.rs
+++ b/crates/penrose_ui/src/core/mod.rs
@@ -216,7 +216,7 @@ impl<'a> Context<'a> {
     /// Render a rectangular border using the supplied color.
     pub fn draw_rect(&mut self, Rect { x, y, w, h }: Rect, color: Color) -> Result<()> {
         let xcol = self.get_or_try_init_xcolor(color)?;
-        let (x, y) = (x as i32, y as i32);
+        let (x, y) = (self.dx + x as i32, self.dy + y as i32);
 
         unsafe {
             XSetForeground(self.dpy, self.s.gc, (*xcol).pixel);
@@ -229,7 +229,7 @@ impl<'a> Context<'a> {
     /// Render a filled rectangle using the supplied color.
     pub fn fill_rect(&mut self, Rect { x, y, w, h }: Rect, color: Color) -> Result<()> {
         let xcol = self.get_or_try_init_xcolor(color)?;
-        let (x, y) = (x as i32, y as i32);
+        let (x, y) = (self.dx + x as i32, self.dy + y as i32);
 
         unsafe {
             XSetForeground(self.dpy, self.s.gc, (*xcol).pixel);
@@ -261,7 +261,7 @@ impl<'a> Context<'a> {
         };
 
         let (lpad, rpad) = (padding.0 as i32, padding.1);
-        let (mut x, y) = (lpad + self.dx, self.dy + h_offset as i32);
+        let (mut x, y) = (lpad + self.dx, self.dy);
         let (mut total_w, mut total_h) = (x as u32, 0);
         let xcol = self.get_or_try_init_xcolor(c)?;
 
@@ -270,7 +270,7 @@ impl<'a> Context<'a> {
             let (chunk_w, chunk_h) = fnt.get_exts(self.dpy, chunk)?;
 
             // SAFETY: fnt pointer is non-null
-            let chunk_y = unsafe { y + (h_offset + chunk_h) as i32 / 2 + (*fnt.xfont).ascent };
+            let chunk_y = unsafe { y + h_offset as i32 + (*fnt.xfont).ascent };
             let c_str = CString::new(chunk)?;
 
             unsafe {

--- a/crates/penrose_ui/src/lib.rs
+++ b/crates/penrose_ui/src/lib.rs
@@ -17,10 +17,6 @@
 //! documentation and `SAFETY` comments in the source code to understand what is happening under
 //! the hood if you have any concerns about this.
 //!
-//! > The `unsafe` nature of FFI code tends to be around correct management of memory and checking
-//! > for null pointers. If there are aspects of the unsafe code in this crate that you suspect are
-//! > unsound please do raise an issue in GitHub detailing the
-//!
 //! [0]: https://github.com/sminez/penrose
 #![warn(
     clippy::complexity,

--- a/crates/penrose_ui/src/lib.rs
+++ b/crates/penrose_ui/src/lib.rs
@@ -11,6 +11,16 @@
 //! The main functionality of this crate is provided through the [`Draw`] nad [`Context`] structs
 //! which allow for simple graphics rendering backed by the xlib and fontconfig libraries.
 //!
+//! ## A note on the use of unsafe code
+//! Given the aims of this crate and the desire to pull in as few dependencies as possible, it
+//! makes heavy use of `unsafe` to wrap C FFI calls. Please make sure that you read the available
+//! documentation and `SAFETY` comments in the source code to understand what is happening under
+//! the hood if you have any concerns about this.
+//!
+//! > The `unsafe` nature of FFI code tends to be around correct management of memory and checking
+//! > for null pointers. If there are aspects of the unsafe code in this crate that you suspect are
+//! > unsound please do raise an issue in GitHub detailing the
+//!
 //! [0]: https://github.com/sminez/penrose
 #![warn(
     clippy::complexity,
@@ -20,7 +30,8 @@
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    rustdoc::all
+    rustdoc::all,
+    clippy::undocumented_unsafe_blocks
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/sminez/penrose/develop/icon.svg",

--- a/crates/penrose_ui/src/lib.rs
+++ b/crates/penrose_ui/src/lib.rs
@@ -96,7 +96,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// WM_NAME property of the root window.
 pub fn status_bar<X: XConn>(
     height: u32,
-    style: &TextStyle,
+    font: &str,
+    point_size: u8,
+    style: TextStyle,
     highlight: impl Into<Color>,
     empty_ws: impl Into<Color>,
     position: Position,
@@ -108,25 +110,25 @@ pub fn status_bar<X: XConn>(
         position,
         height,
         style.bg.unwrap_or_else(|| 0x000000.into()),
-        &style.font,
-        style.point_size,
+        font,
+        point_size,
         vec![
             Box::new(Workspaces::new(style, highlight, empty_ws)),
             Box::new(CurrentLayout::new(style)),
             Box::new(ActiveWindowName::new(
                 max_active_window_chars,
-                &TextStyle {
+                TextStyle {
                     bg: Some(highlight),
                     padding: (6, 4),
-                    ..style.clone()
+                    ..style
                 },
                 true,
                 false,
             )),
             Box::new(RootWindowName::new(
-                &TextStyle {
+                TextStyle {
                     padding: (4, 2),
-                    ..style.clone()
+                    ..style
                 },
                 false,
                 true,

--- a/examples/status_bar/main.rs
+++ b/examples/status_bar/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
         point_size: 8,
         fg: WHITE.into(),
         bg: Some(BLACK.into()),
-        padding: (2.0, 2.0),
+        padding: (2, 2),
     };
 
     let bar = status_bar(BAR_HEIGHT_PX, &style, BLUE, GREY, Position::Top).unwrap();

--- a/examples/status_bar/main.rs
+++ b/examples/status_bar/main.rs
@@ -107,14 +107,12 @@ fn main() -> Result<()> {
     let conn = RustConn::new()?;
     let key_bindings = parse_keybindings_with_xmodmap(raw_key_bindings())?;
     let style = TextStyle {
-        font: FONT.to_string(),
-        point_size: 8,
         fg: WHITE.into(),
         bg: Some(BLACK.into()),
         padding: (2, 2),
     };
 
-    let bar = status_bar(BAR_HEIGHT_PX, &style, BLUE, GREY, Position::Top).unwrap();
+    let bar = status_bar(BAR_HEIGHT_PX, FONT, 8, style, BLUE, GREY, Position::Top).unwrap();
 
     let wm = bar.add_to(WindowManager::new(
         config,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -441,6 +441,8 @@ where
     /// explicitly before calling this method or as part of a startup hook.
     pub fn run(mut self) -> Result<()> {
         info!("registering SIGCHILD signal handler");
+        // SAFETY: there is no previous signal handler so we are safe to set our own without needing
+        //         to worry about UB from the previous handler being invalid.
         if let Err(e) = unsafe { signal(Signal::SIGCHLD, SigHandler::SigIgn) } {
             panic!("unable to set signal handler: {}", e);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,9 +233,6 @@ pub struct Color {
     rgba_hex: u32,
 }
 
-// helper for methods in Color
-macro_rules! _f2u { { $f:expr, $s:expr } => { (($f * 255.0) as u32) << $s } }
-
 impl Color {
     /// Create a new Color from a hex encoded u32: 0xRRGGBB or 0xRRGGBBAA
     pub fn new_from_hex(rgba_hex: u32) -> Self {
@@ -268,13 +265,9 @@ impl Color {
         format!("#{:x}", self.rgb_u32())
     }
 
-    // TODO: Do this with bit operations not floats
-    //
     /// 0xRRGGBB representation of this Color (no alpha information)
     pub fn rgb_u32(&self) -> u32 {
-        let (r, g, b, _) = self.rgba();
-
-        _f2u!(r, 16) + _f2u!(g, 8) + _f2u!(b, 0)
+        self.rgba_hex >> 8
     }
 
     /// 0xRRGGBBAA representation of this Color
@@ -282,13 +275,9 @@ impl Color {
         self.rgba_hex
     }
 
-    // TODO: Do this with bit operations not floats
-    //
     /// 0xAARRGGBB representation of this Color
     pub fn argb_u32(&self) -> u32 {
-        let (r, g, b, a) = self.rgba();
-
-        _f2u!(a, 24) + _f2u!(r, 16) + _f2u!(g, 8) + _f2u!(b, 0)
+        ((self.rgba_hex & 0x000000FF) << 24) + (self.rgba_hex >> 8)
     }
 }
 
@@ -297,6 +286,8 @@ impl From<u32> for Color {
         Self::new_from_hex(hex)
     }
 }
+
+macro_rules! _f2u { { $f:expr, $s:expr } => { (($f * 255.0) as u32) << $s } }
 
 impl From<(f64, f64, f64)> for Color {
     fn from(rgb: (f64, f64, f64)) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
     issue_tracker_base_url = "https://github.com/sminez/penrose/issues/"
 )]
 
-#[cfg(feature = "x11rb-xcb")]
+#[cfg(feature = "x11rb")]
 use ::x11rb::{
     errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError},
     x11_utils::X11Error,
@@ -81,7 +81,7 @@ mod macros;
 pub mod pure;
 pub mod util;
 pub mod x;
-#[cfg(feature = "x11rb-xcb")]
+#[cfg(feature = "x11rb")]
 pub mod x11rb;
 
 #[doc(inline)]
@@ -198,27 +198,27 @@ pub enum Error {
     //       set of common error variants that they can be mapped to without
     //       needing to extend the enum conditionally when flags are enabled
     /// An error that occurred while connecting to an X11 server
-    #[cfg(feature = "x11rb-xcb")]
+    #[cfg(feature = "x11rb")]
     #[error(transparent)]
     X11rbConnect(#[from] ConnectError),
 
     /// An error that occurred on an already established X11 connection
-    #[cfg(feature = "x11rb-xcb")]
+    #[cfg(feature = "x11rb")]
     #[error(transparent)]
     X11rbConnection(#[from] ConnectionError),
 
     /// An error that occurred with some request.
-    #[cfg(feature = "x11rb-xcb")]
+    #[cfg(feature = "x11rb")]
     #[error(transparent)]
     X11rbReplyError(#[from] ReplyError),
 
     /// An error caused by some request or by the exhaustion of IDs.
-    #[cfg(feature = "x11rb-xcb")]
+    #[cfg(feature = "x11rb")]
     #[error(transparent)]
     X11rbReplyOrIdError(#[from] ReplyOrIdError),
 
     /// Representation of an X11 error packet that was sent by the server.
-    #[cfg(feature = "x11rb-xcb")]
+    #[cfg(feature = "x11rb")]
     #[error("X11 error: {0:?}")]
     X11rbX11Error(X11Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,8 @@
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    rustdoc::all
+    rustdoc::all,
+    clippy::undocumented_unsafe_blocks
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/sminez/penrose/develop/icon.svg",

--- a/src/x11rb/mod.rs
+++ b/src/x11rb/mod.rs
@@ -44,9 +44,11 @@ use x11rb::{
     },
     rust_connection::RustConnection,
     wrapper::ConnectionExt as _,
-    xcb_ffi::XCBConnection,
     CURRENT_TIME,
 };
+
+#[cfg(feature = "x11rb-xcb")]
+use x11rb::xcb_ffi::XCBConnection;
 
 pub mod conversions;
 
@@ -109,9 +111,11 @@ impl Conn<RustConnection> {
     }
 }
 
+#[cfg(feature = "x11rb-xcb")]
 /// An C based connection to the X server using an [XCBConnection].
 pub type XcbConn = Conn<XCBConnection>;
 
+#[cfg(feature = "x11rb-xcb")]
 impl Conn<XCBConnection> {
     /// Construct an X11rbConnection  backed by the [x11rb][crate::x11rb] backend using
     /// [x11rb::xcb_ffi::XCBConnection].
@@ -222,6 +226,13 @@ where
         self.flush();
 
         Ok(id)
+    }
+
+    /// Destroy the window identified by the given `Xid`.
+    pub fn destroy_window(&self, id: Xid) -> Result<()> {
+        self.conn.destroy_window(*id)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
See #272 for the details for this one. This work was initially done as an MVP in [sminez/x11-draw](https://github.com/sminez/x11-draw) but there are a number of modifications that are required from the code that is there in order to wire it into the statusbar widget behaviour and layout.

### Breaking changes
This will be a breaking change for the current API around the status bar as a number of things are tidied up where elements of the cairo and pango APIs had bled through to the public API of `penrose_ui` (in particular, using floats for offsets and colour representation...).

- A `Draw` only supports a single primary font (fontconfig is used to find a suitable fallback for missing glyphs)
- Method APIs on the `Draw` and `Context` structs have been modified to no longer bleed through implementation details from pango and cairo (unless you implemented your own fully custom `Widget` this should not affect end users)
- `Context` is now a reference type with a lifetime, providing a view on the surface assigned to a given window.
- `TextStyle` no longer contains font and point size fields: these are set on the `Draw`
- `TextStyle` and individual `Widget` padding, height and offset fields are now `u32` not `f64`
- `TextStyle` is now a Copy type and is passed by value not by reference for all widgets and the status bar
- Constructing a status bar now requires the font and point size as arguments (given that they have been removed from `TextStyle`.

> One additional breaking change is that the status bar (and a `Draw` in general) will only support a single font. The examples provided previously only ever used a single font and behaviour when trying to use multiple fonts has never worked correctly so while this is a breaking API change it's not really a loss in (usable) functionality.

### Version bump and alignment
There are some changes to the main `penrose` crate as well so I'm taking this as an opportunity to align the version numbers of penrose and the additional crates going forward. The APIs between `penrose_ui` / `penrose_keysyms` and `penrose` will only be supported for matching version numbers going forward.