### PR TITLE
Bar flicker

### DIFF
--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -130,8 +130,6 @@ impl<X: XConn> StatusBar<X> {
             let screen_has_focus = self.active_screen == i;
             let mut ctx = self.draw.context_for(id)?;
 
-            ctx.fill_rect(Rect::new(0, 0, w, self.h), self.bg)?;
-
             let mut extents = Vec::with_capacity(self.widgets.len());
             let mut greedy_indices = vec![];
 
@@ -157,7 +155,6 @@ impl<X: XConn> StatusBar<X> {
             for (wd, (w, _)) in self.widgets.iter_mut().zip(extents) {
                 wd.draw(&mut ctx, self.active_screen, screen_has_focus, w, self.h)?;
                 x += w;
-                ctx.flush();
                 ctx.set_x_offset(x as i32);
             }
 

--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -155,6 +155,7 @@ impl<X: XConn> StatusBar<X> {
             for (wd, (w, _)) in self.widgets.iter_mut().zip(extents) {
                 wd.draw(&mut ctx, self.active_screen, screen_has_focus, w, self.h)?;
                 x += w;
+                ctx.flush();
                 ctx.set_x_offset(x as i32);
             }
 

--- a/crates/penrose_ui/src/bar/widgets/simple.rs
+++ b/crates/penrose_ui/src/bar/widgets/simple.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use penrose::{
     core::State,
+    pure::geometry::Rect,
     x::{event::PropertyEvent, Atom, XConn, XConnExt, XEvent},
 };
 
@@ -91,7 +92,7 @@ impl<X: XConn> Widget<X> for ActiveWindowName {
         if f {
             Widget::<X>::draw(&mut self.inner, ctx, s, f, w, h)
         } else {
-            Ok(())
+            ctx.fill_bg(Rect::new(0, 0, w, h))
         }
     }
 

--- a/crates/penrose_ui/src/core/mod.rs
+++ b/crates/penrose_ui/src/core/mod.rs
@@ -348,6 +348,11 @@ impl<'a> Context<'a> {
         Ok(())
     }
 
+    /// Fill the specified area with this Context's background color
+    pub fn fill_bg(&mut self, r: Rect) -> Result<()> {
+        self.fill_rect(r, self.bg)
+    }
+
     /// Render the provided text at the current context offset using the supplied color.
     pub fn draw_text(
         &mut self,


### PR DESCRIPTION
Under the new `0.3.3` API for `penrose_ui` it looks like widgets have a chance to flicker when re-rendering due to there now not being any client side consolidation of rendering actions (the status bar was explicitly filling the full window with its BG color before rendering widgets). The fix for this is to not fill the status bar window before re-rendering but that has a knock on effect of any widget that was not fully filling the bar space it had been assigned was resulting in partial renders or incorrect background colors.

The `ActiveWindowName` widget has been updated to always fill its assigned area rather than expect the bar itself to have cleared what was rendered previously. This _is_ a change in behaviour around the status bar but its one that is fairly easy to address going forward as new widgets are written.