### PR TITLE
Ability to cycle through tags

### DIFF
--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -573,7 +573,7 @@ where
         let i = tags
             .iter()
             .position(|a| a == self.current_tag())
-            .unwrap_or_default();
+            .expect("current tag is a known tag");
 
         let new_i = (i + 1) % tags.len();
         let new_tag = &tags[new_i];
@@ -589,7 +589,7 @@ where
         let i = tags
             .iter()
             .position(|a| a == self.current_tag())
-            .unwrap_or_default();
+            .expect("current tag is a known tag");
 
         let new_i = if i == 0 { tags.len() - 1 } else { i - 1 };
         let new_tag = &tags[new_i];


### PR DESCRIPTION
implements issue #280 
Adds two functions `next_tag` and `previous_tag` which can be called to cycle through tags
let me know if you need me to make any changes