### PR TITLE
#286 - ActiveWindowName widget does not always truncate

### DIFF
--- a/crates/penrose_ui/src/bar/widgets/simple.rs
+++ b/crates/penrose_ui/src/bar/widgets/simple.rs
@@ -126,7 +126,7 @@ impl<X: XConn> Widget<X> for ActiveWindowName {
                 XEvent::PropertyNotify(PropertyEvent { id, atom, .. })
                     if id == focused && name_props.contains(&atom.as_ref()) =>
                 {
-                    self.inner.set_text(x.window_title(*id)?)
+                    self.set_text(x.window_title(*id)?)
                 }
 
                 _ => (),

--- a/crates/penrose_ui/src/bar/widgets/simple.rs
+++ b/crates/penrose_ui/src/bar/widgets/simple.rs
@@ -126,7 +126,7 @@ impl<X: XConn> Widget<X> for ActiveWindowName {
                 XEvent::PropertyNotify(PropertyEvent { id, atom, .. })
                     if id == focused && name_props.contains(&atom.as_ref()) =>
                 {
-                    self.set_text(x.window_title(*id)?)
+                    self.set_text(&x.window_title(*id)?)
                 }
 
                 _ => (),


### PR DESCRIPTION
Making use of the wrapper method that applies name truncation when setting active window name via a property notify event.