### PR TITLE
Adding meta queries to support combinations of queries as queries.

### DIFF
--- a/src/x/query.rs
+++ b/src/x/query.rs
@@ -167,21 +167,21 @@ trait QueryExt<X>: Query<X>
 where
     X: XConn,
 {
-    fn and(self, other: impl Query<X>) -> impl Query<X>
+    fn and(self, other: impl Query<X>) -> AndQuery<Self, impl Query<X>>
     where
         Self: Sized,
     {
         AndQuery(self, other)
     }
 
-    fn or(self, other: impl Query<X>) -> impl Query<X>
+    fn or(self, other: impl Query<X>) -> OrQuery<Self, impl Query<X>>
     where
         Self: Sized,
     {
         OrQuery(self, other)
     }
 
-    fn not(self) -> impl Query<X>
+    fn not(self) -> NotQuery<impl Query<X>>
     where
         Self: Sized,
     {
@@ -195,4 +195,3 @@ where
     Q: Query<X>,
 {
 }
-

--- a/src/x/query.rs
+++ b/src/x/query.rs
@@ -162,3 +162,37 @@ impl<X: XConn> Query<X> for AllQuery<X> {
             .try_fold(true, |acc, query| Ok(acc && query.run(id, x)?))
     }
 }
+
+trait QueryExt<X>: Query<X>
+where
+    X: XConn,
+{
+    fn and(self, other: impl Query<X>) -> impl Query<X>
+    where
+        Self: Sized,
+    {
+        AndQuery(self, other)
+    }
+
+    fn or(self, other: impl Query<X>) -> impl Query<X>
+    where
+        Self: Sized,
+    {
+        OrQuery(self, other)
+    }
+
+    fn not(self) -> impl Query<X>
+    where
+        Self: Sized,
+    {
+        NotQuery(self)
+    }
+}
+
+impl<X, Q> QueryExt<X> for Q
+where
+    X: XConn,
+    Q: Query<X>,
+{
+}
+

--- a/src/x/query.rs
+++ b/src/x/query.rs
@@ -13,7 +13,7 @@ pub trait Query<X: XConn> {
 
     /// Combine this query with another query using a logical AND.
     ///
-    /// NOTE: This follows typical short-circuiting behavior, i.e. if the first query
+    /// This follows typical short-circuiting behavior, i.e. if the first query
     /// returns false, the second query will not be run.
     fn and<Other>(self, other: Other) -> AndQuery<X>
     where
@@ -29,7 +29,7 @@ pub trait Query<X: XConn> {
 
     /// Combine this query with another query using a logical OR.
     ///
-    /// NOTE: This follows typical short-circuiting behavior, i.e. if the first query
+    /// This follows typical short-circuiting behavior, i.e. if the first query
     /// returns true, the second query will not be run.
     fn or<Other>(self, other: Other) -> OrQuery<X>
     where
@@ -44,6 +44,8 @@ pub trait Query<X: XConn> {
     }
 
     /// Apply a logical NOT to this query.
+    ///
+    /// This will invert the result of the query.
     fn not(self) -> NotQuery<X>
     where
         Self: Sized + 'static,


### PR DESCRIPTION
Adding structs:
- `AndQuery`
- `OrQuery`
- `NotQuery`

And combinator methods in the `Query` trait in order to make these usable.