### PR TITLE
Fixes #280 by adding two new methods to StackSet for cycling workspaces

### DIFF
--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -1516,17 +1516,25 @@ mod quickcheck_tests {
     }
 
     #[quickcheck]
-    fn cycling_workspaces_always_changes_workspace(mut s: StackSet<Xid>, next: bool) -> bool {
+    fn focus_next_workspace_always_changes_workspace(mut s: StackSet<Xid>) -> bool {
         if s.ordered_tags().len() == 1 {
             return true; // need at least two tags to cycle
         };
 
         let current_tag = s.current_tag().to_string();
-        if next {
-            s.focus_next_workspace()
-        } else {
-            s.focus_previous_workspace()
+        s.focus_next_workspace();
+
+        s.current_tag() != current_tag
+    }
+
+    #[quickcheck]
+    fn focus_previous_workspace_always_changes_workspace(mut s: StackSet<Xid>) -> bool {
+        if s.ordered_tags().len() == 1 {
+            return true; // need at least two tags to cycle
         };
+
+        let current_tag = s.current_tag().to_string();
+        s.focus_previous_workspace();
 
         s.current_tag() != current_tag
     }


### PR DESCRIPTION
Adding two new methods to `StackSet`: `focus_next_workspace` and `focus_previous_workspace` which behave as their name implies. The definition of "next/previous" is in terms of the semantics of the `ordered_tags` method, so currently in terms of the workspace id. If the semantics of `ordered_tags` changes in future then so will the behaviour of these methods.

Testing wise there is a simple unit test that the cycling methods focus the expected tag both with and without wrapping at either end of the workspace list, along with a quickcheck test that for arbitrary `StackSets` with at least two workspaces we always change the focused workspace when calling either method.