### PR TITLE
#297 improving the behaviour of IntervalText to run all updates in a single thread

### DIFF
--- a/crates/penrose_ui/src/bar/schedule.rs
+++ b/crates/penrose_ui/src/bar/schedule.rs
@@ -1,0 +1,104 @@
+//! Utilities for running scheduled updates to widgets
+use crate::bar::widgets::Text;
+use penrose::util::spawn_with_args;
+use std::{
+    cmp::max,
+    fmt,
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+use tracing::{debug, trace};
+
+/// The minimum allowed interval for an [UpdateSchedule].
+pub const MIN_DURATION: Duration = Duration::from_secs(1);
+
+/// For widgets that want to have their content updated periodically by the status bar by calling
+/// an external function.
+///
+/// See [IntervalText] for a simple implementation of this behaviour
+pub struct UpdateSchedule {
+    pub(crate) next: Instant,
+    pub(crate) interval: Duration,
+    pub(crate) get_text: Box<dyn Fn() -> Option<String> + Send + 'static>,
+    pub(crate) txt: Arc<Mutex<Text>>,
+}
+
+impl fmt::Debug for UpdateSchedule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpdateSchedule")
+            .field("next", &self.next)
+            .field("interval", &self.interval)
+            .field("txt", &self.txt)
+            .finish()
+    }
+}
+
+impl UpdateSchedule {
+    /// Construct a new [UpdateSchedule] specifying the interval that the [Widget] content should
+    /// be updated on and an update function for producing the widget content.
+    ///
+    /// The updated content will then be stored in the provided `Arc<Mutex<Text>>` for access
+    /// within your widget logic.
+    pub fn new(
+        interval: Duration,
+        get_text: Box<dyn Fn() -> Option<String> + Send + 'static>,
+        txt: Arc<Mutex<Text>>,
+    ) -> Self {
+        if interval < MIN_DURATION {
+            panic!("UpdateSchedule interval is too small: {interval:?} < {MIN_DURATION:?}");
+        }
+
+        Self {
+            next: Instant::now(),
+            interval,
+            get_text,
+            txt,
+        }
+    }
+
+    /// Call our `get_text` function to update the contents of our paired [CronText] and then bump
+    /// our `next` time to the next interval point.
+    ///
+    /// This is gives us behaviour of a consistent interval between invocation end/start but not
+    /// necessarily a consistent interval between start/start depending on how long `get_text`
+    /// takes to run.
+    fn update_text(&mut self) {
+        trace!("running UpdateSchedule get_text");
+        let s = (self.get_text)();
+        trace!(?s, "ouput from running get_text");
+
+        if let Some(s) = s {
+            let mut t = match self.txt.lock() {
+                Ok(inner) => inner,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            t.set_text(s);
+        }
+
+        let next = self.next + self.interval;
+        let now = Instant::now();
+        self.next = max(next, now);
+        trace!(next = ?self.next, "next update at");
+    }
+}
+
+/// Run the polling thread for a set of [UpdateSchedule]s and update their contents on
+/// their requested intervals.
+pub(crate) fn run_update_schedules(mut schedules: Vec<UpdateSchedule>) {
+    thread::spawn(move || loop {
+        debug!("running UpdateSchedule updates for all pending widgets");
+        while schedules[0].next < Instant::now() {
+            schedules[0].update_text();
+            schedules.sort_by(|a, b| a.next.cmp(&b.next));
+        }
+
+        // FIXME: this is a hack at the moment to ensure that an event drops into the main
+        // window manager event loop and triggers the `on_event` hook of the status bar.
+        let _ = spawn_with_args("xsetroot", &["-name", ""]);
+
+        let interval = schedules[0].next - Instant::now();
+        debug!(?interval, "sleeping until next update point");
+        thread::sleep(interval);
+    });
+}

--- a/crates/penrose_ui/src/bar/widgets/sys.rs
+++ b/crates/penrose_ui/src/bar/widgets/sys.rs
@@ -1,125 +1,200 @@
-//! System monitor widgets
-use crate::bar::widgets::{RefreshText, TextStyle};
-use penrose::util::{spawn_for_output, spawn_for_output_with_args};
-use std::fs;
+//! System monitor widgets and utility functions
 
-/// Display the current charge level and status of a named battery.
-///
-/// If the given battery name is not found on this system, this widget will
-/// render as an empty string.
-pub fn battery_summary(bat: &'static str, style: TextStyle) -> RefreshText {
-    RefreshText::new(style, move || battery_text(bat).unwrap_or_default())
-}
+/// Helper functions for obtaining system information for use in status bar widgets
+pub mod helpers {
+    use penrose::util::{spawn_for_output, spawn_for_output_with_args};
+    use std::fs;
 
-fn battery_text(bat: &str) -> Option<String> {
-    let status = read_sys_file(bat, "status")?;
-    let energy_now: u32 = read_sys_file(bat, "charge_now")?.parse().ok()?;
-    let energy_full: u32 = read_sys_file(bat, "charge_full")?.parse().ok()?;
+    /// Fetch the requested battery's charge as a percentage of its total along with an indicator
+    /// of whether it is charging or discharging.
+    ///
+    /// This will return `None` if it is unable to read or parse the required system files for the
+    /// requested battery.
+    pub fn battery_text(bat: &str) -> Option<String> {
+        let status = read_sys_file(bat, "status")?;
+        let energy_now: u32 = read_sys_file(bat, "charge_now")?.parse().ok()?;
+        let energy_full: u32 = read_sys_file(bat, "charge_full")?.parse().ok()?;
 
-    let charge = energy_now * 100 / energy_full;
+        let charge = energy_now * 100 / energy_full;
 
-    let icon = if status == "Charging" {
-        ""
-    } else if charge >= 90 || status == "Full" {
-        ""
-    } else if charge >= 70 {
-        ""
-    } else if charge >= 50 {
-        ""
-    } else if charge >= 20 {
-        ""
-    } else {
-        ""
-    };
+        let icon = if status == "Charging" {
+            ""
+        } else if charge >= 90 || status == "Full" {
+            ""
+        } else if charge >= 70 {
+            ""
+        } else if charge >= 50 {
+            ""
+        } else if charge >= 20 {
+            ""
+        } else {
+            ""
+        };
 
-    Some(format!("{icon} {charge}%"))
-}
-
-fn read_sys_file(bat: &str, fname: &str) -> Option<String> {
-    fs::read_to_string(format!("/sys/class/power_supply/{bat}/{fname}"))
-        .ok()
-        .map(|s| s.trim().to_string())
-}
-
-/// Display the current date and time in YYYY-MM-DD HH:MM format
-///
-/// This widget shells out to the `date` tool to generate its output
-pub fn current_date_and_time(style: TextStyle) -> RefreshText {
-    RefreshText::new(style, || {
-        spawn_for_output_with_args("date", &["+%F %R"])
-            .unwrap_or_default()
-            .trim()
-            .to_string()
-    })
-}
-
-/// Display the ESSID currently connected to and the signal quality as
-/// a percentage.
-pub fn wifi_network(style: TextStyle) -> RefreshText {
-    RefreshText::new(style, move || wifi_text().unwrap_or_default())
-}
-
-fn wifi_text() -> Option<String> {
-    let (interface, essid) = interface_and_essid()?;
-    let signal = signal_quality(&interface)?;
-
-    Some(format!("<{essid} {signal}%>"))
-}
-
-// Read the interface name and essid via iwgetid.
-//   Output format is '$interface    ESSID:"$essid"'
-fn interface_and_essid() -> Option<(String, String)> {
-    let raw = spawn_for_output("iwgetid").ok()?;
-    let mut iter = raw.split(':');
-
-    // Not using split_whitespace here as the essid may contain whitespace
-    let interface = iter.next()?.split_whitespace().next()?.to_owned();
-    let essid = iter.next()?.split('"').nth(1)?.to_string();
-
-    Some((interface, essid))
-}
-
-// Parsing the format described here: https://hewlettpackard.github.io/wireless-tools/Linux.Wireless.Extensions.html
-fn signal_quality(interface: &str) -> Option<String> {
-    let raw = fs::read_to_string("/proc/net/wireless").ok()?;
-
-    for line in raw.lines() {
-        if line.starts_with(interface) {
-            return Some(
-                line.split_whitespace()
-                    .nth(2)?
-                    .strip_suffix('.')?
-                    .to_owned(),
-            );
-        }
+        Some(format!("{icon} {charge}%"))
     }
 
-    None
+    fn read_sys_file(bat: &str, fname: &str) -> Option<String> {
+        fs::read_to_string(format!("/sys/class/power_supply/{bat}/{fname}"))
+            .ok()
+            .map(|s| s.trim().to_string())
+    }
+
+    /// Fetch the current date and time in `YYYY-MM-DD HH:MM` format using the `date` command line
+    /// program.
+    ///
+    /// Will return `None` if there are errors in calling `date`.
+    pub fn date_text() -> Option<String> {
+        Some(
+            spawn_for_output_with_args("date", &["+%F %R"])
+                .ok()?
+                .trim()
+                .to_string(),
+        )
+    }
+
+    /// Fetch the active ESSID and associated signal quality for the active wifi network.
+    ///
+    /// Makes use of the `iwgetid` command line program and will return `None` if there are errors
+    /// in calling it or reading required system files to determine the signal quality.
+    pub fn wifi_text() -> Option<String> {
+        let (interface, essid) = interface_and_essid()?;
+        let signal = signal_quality(&interface)?;
+
+        Some(format!("<{essid} {signal}%>"))
+    }
+
+    // Read the interface name and essid via iwgetid.
+    //   Output format is '$interface    ESSID:"$essid"'
+    fn interface_and_essid() -> Option<(String, String)> {
+        let raw = spawn_for_output("iwgetid").ok()?;
+        let mut iter = raw.split(':');
+
+        // Not using split_whitespace here as the essid may contain whitespace
+        let interface = iter.next()?.split_whitespace().next()?.to_owned();
+        let essid = iter.next()?.split('"').nth(1)?.to_string();
+
+        Some((interface, essid))
+    }
+
+    // Parsing the format described here: https://hewlettpackard.github.io/wireless-tools/Linux.Wireless.Extensions.html
+    fn signal_quality(interface: &str) -> Option<String> {
+        let raw = fs::read_to_string("/proc/net/wireless").ok()?;
+
+        for line in raw.lines() {
+            if line.starts_with(interface) {
+                return Some(
+                    line.split_whitespace()
+                        .nth(2)?
+                        .strip_suffix('.')?
+                        .to_owned(),
+                );
+            }
+        }
+
+        None
+    }
+
+    /// Parse the current volume as a percentage from amixer.
+    ///
+    /// Expected output format:
+    ///   $ amixer sget Master
+    ///     Simple mixer control 'Master',0
+    ///       Capabilities: pvolume pvolume-joined pswitch pswitch-joined
+    ///       Playback channels: Mono
+    ///       Limits: Playback 0 - 127
+    ///       Mono: Playback 0 [0%] [-63.50dB] [on]
+    pub fn amixer_text(channel: &str) -> Option<String> {
+        let raw = spawn_for_output(format!("amixer sget {channel}")).ok()?;
+
+        let vol = raw
+            .lines()
+            .last()?
+            .split_whitespace()
+            .find(|s| s.ends_with("%]"))?
+            .replace(|c| "[]%".contains(c), "");
+
+        Some(format!(" {vol}%"))
+    }
 }
 
-/// Display the current volume level as reported by `amixer`
-pub fn amixer_volume(channel: &'static str, style: TextStyle) -> RefreshText {
-    RefreshText::new(style, move || amixer_text(channel).unwrap_or_default())
+/// System information widgets provided as [RefreshText] widgets.
+///
+/// These will update themselves every time that the window manager refreshes its internal state.
+/// To update on a specified interval instead, see the [interval] module instead.
+pub mod refresh {
+    use crate::bar::widgets::{sys::helpers, RefreshText, TextStyle};
+
+    /// Display the current charge level and status of a named battery.
+    ///
+    /// If the given battery name is not found on this system, this widget will
+    /// render as an empty string.
+    pub fn battery_summary(bat: &'static str, style: TextStyle) -> RefreshText {
+        RefreshText::new(style, move || {
+            helpers::battery_text(bat).unwrap_or_default()
+        })
+    }
+
+    /// Display the current date and time in YYYY-MM-DD HH:MM format
+    ///
+    /// This widget shells out to the `date` tool to generate its output
+    pub fn current_date_and_time(style: TextStyle) -> RefreshText {
+        RefreshText::new(style, || helpers::date_text().unwrap_or_default())
+    }
+
+    /// Display the ESSID currently connected to and the signal quality as
+    /// a percentage.
+    pub fn wifi_network(style: TextStyle) -> RefreshText {
+        RefreshText::new(style, move || helpers::wifi_text().unwrap_or_default())
+    }
+
+    /// Display the current volume level as reported by `amixer`
+    pub fn amixer_volume(channel: &'static str, style: TextStyle) -> RefreshText {
+        RefreshText::new(style, move || {
+            helpers::amixer_text(channel).unwrap_or_default()
+        })
+    }
 }
 
-// Parse the current volume as a percentage from amixer.
-//
-// Expected output format:
-//   $ amixer sget Master
-//     Simple mixer control 'Master',0
-//       Capabilities: pvolume pvolume-joined pswitch pswitch-joined
-//       Playback channels: Mono
-//       Limits: Playback 0 - 127
-//       Mono: Playback 0 [0%] [-63.50dB] [on]
-fn amixer_text(channel: &str) -> Option<String> {
-    let raw = spawn_for_output(format!("amixer sget {channel}")).ok()?;
+/// System information widgets provided as [IntervalText] widgets.
+///
+/// These will update themselves based on the interval provided. To update when the window manager
+/// refreshes its internal state, see the [refresh] module instead.
+pub mod interval {
+    use crate::bar::widgets::{sys::helpers, IntervalText, TextStyle};
+    use std::time::Duration;
 
-    let vol = raw
-        .lines()
-        .last()?
-        .split_whitespace()
-        .find(|s| s.ends_with("%]"))?
-        .replace(|c| "[]%".contains(c), "");
+    /// Display the current charge level and status of a named battery.
+    ///
+    /// If the given battery name is not found on this system, this widget will
+    /// render as an empty string.
+    pub fn battery_summary(
+        bat: &'static str,
+        style: TextStyle,
+        interval: Duration,
+    ) -> IntervalText {
+        IntervalText::new(style, move || helpers::battery_text(bat), interval)
+    }
 
-    Some(format!(" {vol}%"))
+    /// Display the current date and time in YYYY-MM-DD HH:MM format
+    ///
+    /// This widget shells out to the `date` tool to generate its output
+    pub fn current_date_and_time(style: TextStyle, interval: Duration) -> IntervalText {
+        IntervalText::new(style, helpers::date_text, interval)
+    }
+
+    /// Display the ESSID currently connected to and the signal quality as
+    /// a percentage.
+    pub fn wifi_network(style: TextStyle, interval: Duration) -> IntervalText {
+        IntervalText::new(style, helpers::wifi_text, interval)
+    }
+
+    /// Display the current volume level as reported by `amixer`
+    pub fn amixer_volume(
+        channel: &'static str,
+        style: TextStyle,
+        interval: Duration,
+    ) -> IntervalText {
+        IntervalText::new(style, move || helpers::amixer_text(channel), interval)
+    }
 }

--- a/crates/penrose_ui/src/lib.rs
+++ b/crates/penrose_ui/src/lib.rs
@@ -22,12 +22,12 @@
     clippy::complexity,
     clippy::correctness,
     clippy::style,
+    clippy::undocumented_unsafe_blocks,
     future_incompatible,
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
-    rustdoc::all,
-    clippy::undocumented_unsafe_blocks
+    rustdoc::all
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/sminez/penrose/develop/icon.svg",


### PR DESCRIPTION
See #297 for details.

This doesn't make any breaking API changes, but the imports for the existing `sys` widgets have been moved to support providing both `RefreshText` and `IntervalText` variants, so anyone making use of those widgets will need to adjust their `use` statements accordingly.