### PR TITLE
fixing #113 and adding proper mouse support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -30,7 +30,7 @@ x11rb-xcb = ["x11rb", "x11rb/allow-unsafe-code"]
 anymap = "0.12"
 bitflags = { version = "2.5", features = ["serde"] }
 nix = { version = "0.29", default-features = false, features = ["signal"] }
-penrose_keysyms = { version = "0.3.4", path = "crates/penrose_keysyms", optional = true }
+penrose_keysyms = { version = "0.3.6", path = "crates/penrose_keysyms", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0"

--- a/crates/penrose_keysyms/Cargo.toml
+++ b/crates/penrose_keysyms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_keysyms"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["IDAM <innes.andersonmorrison@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/crates/penrose_ui/Cargo.toml
+++ b/crates/penrose_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose_ui"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -12,7 +12,7 @@ description = "UI elements for the penrose window manager library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-penrose = { version = "0.3.5", path = "../../" }
+penrose = { version = "0.3.6", path = "../../" }
 tracing = { version = "0.1", features = ["attributes"] }
 thiserror = "1.0"
 yeslogic-fontconfig-sys = "5.0"

--- a/src/builtin/actions/floating.rs
+++ b/src/builtin/actions/floating.rs
@@ -1,8 +1,16 @@
 //! Actions for manipulating floating windows.
 use crate::{
-    builtin::actions::{key_handler, modify_with},
-    core::bindings::KeyEventHandler,
+    builtin::actions::{key_handler, modify_with, mouse_modify_with},
+    core::{
+        bindings::{
+            KeyEventHandler, MotionNotifyEvent, MouseEvent, MouseEventHandler, MouseEventKind,
+        },
+        State,
+    },
+    custom_error,
+    pure::geometry::{Point, Rect},
     x::{XConn, XConnExt},
+    Result, Xid,
 };
 use tracing::error;
 
@@ -92,4 +100,153 @@ pub fn float_all<X: XConn>() -> Box<dyn KeyEventHandler<X>> {
 /// Sink all floating windows back into their tiled positions
 pub fn sink_all<X: XConn>() -> Box<dyn KeyEventHandler<X>> {
     modify_with(|cs| cs.floating.clear())
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ClickData {
+    x_initial: i32,
+    y_initial: i32,
+    r_initial: Rect,
+}
+
+impl ClickData {
+    fn on_motion<X: XConn>(
+        &self,
+        f: impl Fn(&mut Rect, i32, i32),
+        id: Xid,
+        rpt: Point,
+        state: &mut State<X>,
+        x: &X,
+    ) -> Result<()> {
+        let (dx, dy) = (rpt.x as i32 - self.x_initial, rpt.y as i32 - self.y_initial);
+
+        let mut r = self.r_initial;
+        (f)(&mut r, dx, dy);
+
+        state.client_set.float(id, r)?;
+        x.position_client(id, r)?;
+
+        Ok(())
+    }
+}
+
+trait ClickWrapper {
+    fn data(&mut self) -> &mut Option<ClickData>;
+
+    fn motion_fn(&self) -> impl Fn(&mut Rect, i32, i32);
+
+    fn on_mouse_event<X: XConn>(
+        &mut self,
+        evt: &MouseEvent,
+        state: &mut State<X>,
+        x: &X,
+    ) -> Result<()> {
+        let id = evt.data.id;
+
+        match evt.kind {
+            MouseEventKind::Press => {
+                let r_client = x.client_geometry(id)?;
+                state.client_set.float(id, r_client)?;
+                *self.data() = Some(ClickData {
+                    x_initial: evt.data.rpt.x as i32,
+                    y_initial: evt.data.rpt.y as i32,
+                    r_initial: r_client,
+                });
+            }
+
+            MouseEventKind::Release => *self.data() = None,
+        }
+
+        Ok(())
+    }
+
+    fn on_motion<X: XConn>(
+        &mut self,
+        evt: &MotionNotifyEvent,
+        state: &mut State<X>,
+        x: &X,
+    ) -> Result<()> {
+        match *self.data() {
+            Some(data) => data.on_motion(self.motion_fn(), evt.data.id, evt.data.rpt, state, x),
+            None => Err(custom_error!("mouse motion without held state")),
+        }
+    }
+}
+
+/// A simple mouse event handler for dragging a window
+#[derive(Debug, Default, Clone)]
+pub struct MouseDragHandler {
+    data: Option<ClickData>,
+}
+
+impl MouseDragHandler {
+    /// Construct a boxed [MouseEventHandler] trait object ready to be added to your bindings
+    pub fn boxed_default<X: XConn>() -> Box<dyn MouseEventHandler<X>> {
+        Box::<MouseDragHandler>::default()
+    }
+}
+
+impl ClickWrapper for MouseDragHandler {
+    fn data(&mut self) -> &mut Option<ClickData> {
+        &mut self.data
+    }
+
+    fn motion_fn(&self) -> impl Fn(&mut Rect, i32, i32) {
+        |r, dx, dy| r.reposition(dx, dy)
+    }
+}
+
+impl<X: XConn> MouseEventHandler<X> for MouseDragHandler {
+    fn on_mouse_event(&mut self, evt: &MouseEvent, state: &mut State<X>, x: &X) -> Result<()> {
+        ClickWrapper::on_mouse_event(self, evt, state, x)
+    }
+
+    fn on_motion(&mut self, evt: &MotionNotifyEvent, state: &mut State<X>, x: &X) -> Result<()> {
+        ClickWrapper::on_motion(self, evt, state, x)
+    }
+}
+
+/// A simple mouse event handler for resizing a window
+#[derive(Debug, Default, Clone)]
+pub struct MouseResizeHandler {
+    data: Option<ClickData>,
+}
+
+impl MouseResizeHandler {
+    /// Construct a boxed [MouseEventHandler] trait object ready to be added to your bindings
+    pub fn boxed_default<X: XConn>() -> Box<dyn MouseEventHandler<X>> {
+        Box::<MouseResizeHandler>::default()
+    }
+}
+
+impl ClickWrapper for MouseResizeHandler {
+    fn data(&mut self) -> &mut Option<ClickData> {
+        &mut self.data
+    }
+
+    fn motion_fn(&self) -> impl Fn(&mut Rect, i32, i32) {
+        |r, dw, dh| r.resize(dw, dh)
+    }
+}
+
+impl<X: XConn> MouseEventHandler<X> for MouseResizeHandler {
+    fn on_mouse_event(&mut self, evt: &MouseEvent, state: &mut State<X>, x: &X) -> Result<()> {
+        ClickWrapper::on_mouse_event(self, evt, state, x)
+    }
+
+    fn on_motion(&mut self, evt: &MotionNotifyEvent, state: &mut State<X>, x: &X) -> Result<()> {
+        ClickWrapper::on_motion(self, evt, state, x)
+    }
+}
+
+/// Sink the current window back into tiling mode if it was floating
+pub fn sink_clicked<X: XConn>() -> Box<dyn MouseEventHandler<X>> {
+    mouse_modify_with(|cs| {
+        let id = match cs.current_client() {
+            Some(&id) => id,
+            None => return,
+        };
+
+        cs.sink(&id);
+    })
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -86,8 +86,6 @@ where
     pub(crate) diff: Diff<Xid>,
     pub(crate) running: bool,
     pub(crate) held_mouse_state: Option<MouseState>,
-    // pub(crate) mouse_focused: bool,
-    // pub(crate) mouse_position: Option<(Point, Point)>,
 }
 
 impl<X> State<X>

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod handle;
 pub mod hooks;
 pub mod layout;
 
-use bindings::{KeyBindings, MouseBindings};
+use bindings::{KeyBindings, MouseBindings, MouseState};
 use hooks::{EventHook, LayoutHook, ManageHook, StateHook};
 use layout::{Layout, LayoutStack};
 
@@ -85,6 +85,7 @@ where
     pub(crate) current_event: Option<XEvent>,
     pub(crate) diff: Diff<Xid>,
     pub(crate) running: bool,
+    pub(crate) held_mouse_state: Option<MouseState>,
     // pub(crate) mouse_focused: bool,
     // pub(crate) mouse_position: Option<(Point, Point)>,
 }
@@ -113,6 +114,7 @@ where
             current_event: None,
             diff,
             running: false,
+            held_mouse_state: None,
         })
     }
 
@@ -545,6 +547,7 @@ where
             MappingNotify => handle::mapping_notify(key_bindings, mouse_bindings, x)?,
             MapRequest(xid) => handle::map_request(*xid, state, x)?,
             MouseEvent(e) => handle::mouse_event(e.clone(), mouse_bindings, state, x)?,
+            MotionNotify(e) => handle::motion_event(e.clone(), mouse_bindings, state, x)?,
             PropertyNotify(_) => (), // Not currently handled
             RandrNotify => handle::detect_screens(state, x)?,
             ScreenChange => handle::screen_change(state, x)?,

--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -761,6 +761,7 @@ impl StackSet<Xid> {
             current_event: None,
             diff: Default::default(),
             running: false,
+            held_mouse_state: None,
         };
 
         s.visible_client_positions(&crate::x::StubXConn)

--- a/src/x/event.rs
+++ b/src/x/event.rs
@@ -1,6 +1,6 @@
 //! Data types for working with X events
 use crate::{
-    core::bindings::{KeyCode, MouseEvent},
+    core::bindings::{KeyCode, MotionNotifyEvent, MouseEvent},
     pure::geometry::{Point, Rect},
     x::{Atom, XConn},
     Result, Xid,
@@ -40,8 +40,10 @@ pub enum XEvent {
     MappingNotify,
     /// A client window is requesting to be positioned and rendered on the screen.
     MapRequest(Xid),
-    /// The mouse has moved or a mouse button has been pressed
+    /// A mouse button has been pressed or released
     MouseEvent(MouseEvent),
+    /// The mouse has moved or a mouse button has been pressed
+    MotionNotify(MotionNotifyEvent),
     /// A client property has changed in some way
     PropertyNotify(PropertyEvent),
     /// A randr action has occured (new outputs, resolution change etc)
@@ -71,6 +73,7 @@ impl std::fmt::Display for XEvent {
             MappingNotify => write!(f, "MappingNotify"),
             MapRequest(_) => write!(f, "MapRequest"),
             MouseEvent(_) => write!(f, "MouseEvent"),
+            MotionNotify(_) => write!(f, "MotionNotify"),
             PropertyNotify(_) => write!(f, "PropertyNotify"),
             RandrNotify => write!(f, "RandrNotify"),
             ResizeRequest(_) => write!(f, "ResizeRequest"),

--- a/src/x11rb/conversions.rs
+++ b/src/x11rb/conversions.rs
@@ -1,6 +1,9 @@
 //! Conversions to Penrose types from X11rb types
 use crate::{
-    core::bindings::{KeyCode, ModifierKey, MouseButton, MouseEvent, MouseEventKind, MouseState},
+    core::bindings::{
+        KeyCode, ModifierKey, MotionNotifyEvent, MouseButton, MouseEvent, MouseEventKind,
+        MouseState,
+    },
     pure::geometry::{Point, Rect},
     x::{
         event::{
@@ -31,7 +34,7 @@ pub(crate) fn convert_event<C: Connection>(conn: &Conn<C>, event: Event) -> Resu
 
         Event::ButtonPress(event) => Ok(to_mouse_state(event.detail, event.state).map(|state| {
             XEvent::MouseEvent(MouseEvent::new(
-                Xid(event.event),
+                Xid(event.child),
                 event.root_x,
                 event.root_y,
                 event.event_x,
@@ -43,7 +46,7 @@ pub(crate) fn convert_event<C: Connection>(conn: &Conn<C>, event: Event) -> Resu
 
         Event::ButtonRelease(event) => Ok(to_mouse_state(event.detail, event.state).map(|state| {
             XEvent::MouseEvent(MouseEvent::new(
-                Xid(event.event),
+                Xid(event.child),
                 event.root_x,
                 event.root_y,
                 event.event_x,
@@ -53,16 +56,15 @@ pub(crate) fn convert_event<C: Connection>(conn: &Conn<C>, event: Event) -> Resu
             ))
         })),
 
-        // FIXME: The 5 is due to https://github.com/sminez/penrose/issues/113
-        Event::MotionNotify(event) => Ok(to_mouse_state(5, event.state).map(|state| {
-            XEvent::MouseEvent(MouseEvent::new(
-                Xid(event.event),
+        // NOTE: the '1' here is not actually used
+        Event::MotionNotify(event) => Ok(to_mouse_state(1, event.state).map(|state| {
+            XEvent::MotionNotify(MotionNotifyEvent::new(
+                Xid(event.child),
                 event.root_x,
                 event.root_y,
                 event.event_x,
                 event.event_y,
-                state,
-                MouseEventKind::Motion,
+                state.modifiers,
             ))
         })),
 


### PR DESCRIPTION
Thanks to @favilo for the initial implementation that this was inspired by (found [here](https://github.com/favilo/favilrose/blob/e7c02964cf7187d9631a85abc48462cac61df398/src/mouse.rs#L37)) and apologies to @psychon for not addressing the issue with motion notify events until now...!

This change includes a breaking API change to how mouse bindings are defined: rather than bindings being tied individually to press, release and motion the `MouseEventHandler` trait now defines a handler that is responsible for all three for a given button press and modifier set. As a demonstration of how this looks, this is the simple mouse bindings that are now present in the `minimal` example:

```rust
fn mouse_bindings() -> HashMap<MouseState, Box<dyn MouseEventHandler<RustConn>>> {
    use penrose::core::bindings::{
        ModifierKey::{Meta, Shift},
        MouseButton::{Left, Middle, Right},
    };

    map! {
        map_keys: |(button, modifiers)| MouseState { button, modifiers };

        (Left, vec![Shift, Meta]) => MouseDragHandler::boxed_default(),
        (Right, vec![Shift, Meta]) => MouseResizeHandler::boxed_default(),
        (Middle, vec![Shift, Meta]) => sink_clicked(),
    }
}
```


https://github.com/sminez/penrose/assets/8116092/bba44d3d-11b5-4e9f-9728-feaa6f5b36ce

