### PR TITLE
Only honour removal of fullscreen state if the state is currently present

### DIFF
--- a/crates/penrose_ui/src/bar/schedule.rs
+++ b/crates/penrose_ui/src/bar/schedule.rs
@@ -8,7 +8,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use tracing::{debug, trace};
+use tracing::trace;
 
 /// The minimum allowed interval for an [UpdateSchedule].
 pub const MIN_DURATION: Duration = Duration::from_secs(1);
@@ -87,7 +87,7 @@ impl UpdateSchedule {
 /// their requested intervals.
 pub(crate) fn run_update_schedules(mut schedules: Vec<UpdateSchedule>) {
     thread::spawn(move || loop {
-        debug!("running UpdateSchedule updates for all pending widgets");
+        trace!("running UpdateSchedule updates for all pending widgets");
         while schedules[0].next < Instant::now() {
             schedules[0].update_text();
             schedules.sort_by(|a, b| a.next.cmp(&b.next));
@@ -98,7 +98,7 @@ pub(crate) fn run_update_schedules(mut schedules: Vec<UpdateSchedule>) {
         let _ = spawn_with_args("xsetroot", &["-name", ""]);
 
         let interval = schedules[0].next - Instant::now();
-        debug!(?interval, "sleeping until next update point");
+        trace!(?interval, "sleeping until next update point");
         thread::sleep(interval);
     });
 }

--- a/src/extensions/actions/mod.rs
+++ b/src/extensions/actions/mod.rs
@@ -52,7 +52,7 @@ pub fn set_fullscreen_state<X: XConn>(
             .r;
         state.client_set.float(id, r)?;
         wstate.push(*full_screen);
-    } else if action == Remove || (action == Toggle && currently_fullscreen) {
+    } else if currently_fullscreen && (action == Remove || action == Toggle) {
         state.client_set.sink(&id);
         wstate.retain(|&val| val != *full_screen);
     }

--- a/src/extensions/actions/mod.rs
+++ b/src/extensions/actions/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     x::{atom::Atom, property::Prop, XConn, XConnExt},
     Error, Result, Xid,
 };
-use tracing::error;
+use tracing::{debug, error};
 
 mod dynamic_select;
 
@@ -42,6 +42,7 @@ pub fn set_fullscreen_state<X: XConn>(
     };
 
     let currently_fullscreen = wstate.contains(&full_screen);
+    debug!(%currently_fullscreen, ?action, %id, "setting fullscreen state");
 
     if action == Add || (action == Toggle && !currently_fullscreen) {
         let r = state
@@ -86,7 +87,7 @@ pub fn toggle_fullscreen<X: XConn>() -> Box<dyn KeyEventHandler<X>> {
 /// DefaultWorkspace hook that allows for auto populating named Workspaces when first focusing them.
 ///
 /// > If you just want to dynamically select an existing workspace then you can use
-/// [switch_to_workspace] to select from known workspace names.
+/// > [switch_to_workspace] to select from known workspace names.
 ///
 ///   [0]: crate::pure::Workspace
 pub fn create_or_switch_to_workspace<X>(

--- a/src/extensions/hooks/ewmh.rs
+++ b/src/extensions/hooks/ewmh.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     Result, Xid,
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// The set of Atoms this extension adds support for.
 ///
@@ -94,6 +94,8 @@ pub fn event_hook<X: XConn>(event: &XEvent, state: &mut State<X>, x: &X) -> Resu
         XEvent::ClientMessage(m) => m,
         _ => return Ok(true),
     };
+
+    debug!(?dtype, "processing client message in ewmh hook");
 
     match dtype.as_ref() {
         // Focus the requested desktop

--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -15,6 +15,7 @@ use std::{
     hash::Hash,
     mem::{swap, take},
 };
+use tracing::debug;
 
 /// The side-effect free internal state representation of the window manager.
 #[derive(Default, Debug, Clone)]
@@ -259,6 +260,7 @@ where
     pub(crate) fn float_unchecked<R: RelativeTo>(&mut self, client: C, r: R) {
         let screen = self.screen_for_client(&client).expect("client to be known");
         let r = r.relative_to(&screen.r);
+        debug!(?r, "setting floating position");
         self.floating.insert(client, r);
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{
     io::Read,
     process::{Command, Stdio},
 };
-use tracing::debug;
+use tracing::trace;
 
 /// Run an external command
 ///
@@ -58,7 +58,7 @@ pub fn spawn_with_args<S: Into<String>>(cmd: S, args: &[&str]) -> Result<()> {
 /// > output of a process that you spawn.
 pub fn spawn_for_output<S: Into<String>>(cmd: S) -> std::io::Result<String> {
     let cmd = cmd.into();
-    debug!(?cmd, "spawning subprocess for output");
+    trace!(?cmd, "spawning subprocess for output");
     let parts: Vec<&str> = cmd.split_whitespace().collect();
     let result = if parts.len() > 1 {
         Command::new(parts[0])
@@ -69,7 +69,7 @@ pub fn spawn_for_output<S: Into<String>>(cmd: S) -> std::io::Result<String> {
         Command::new(parts[0]).stdout(Stdio::piped()).spawn()
     };
 
-    debug!(?cmd, "reading output");
+    trace!(?cmd, "reading output");
     let mut child = result?;
     let mut buff = String::new();
     child
@@ -91,13 +91,13 @@ pub fn spawn_for_output_with_args<S: Into<String>>(
 ) -> std::io::Result<String> {
     let cmd = cmd.into();
 
-    debug!(?cmd, ?args, "spawning subprocess for output");
+    trace!(?cmd, ?args, "spawning subprocess for output");
     let mut child = Command::new(&cmd)
         .stdout(Stdio::piped())
         .args(args)
         .spawn()?;
 
-    debug!(?cmd, ?args, "reading output");
+    trace!(?cmd, ?args, "reading output");
     let mut buff = String::new();
     child
         .stdout


### PR DESCRIPTION
The logic for the ewmh hook that handles changes to full screen state was unconditionally honouring requests to remove full screen state even when the client in question was not currently full screen. This lead to clients losing their floating position within the window manager state as we `sink` the client in question as part of this due to our full screen implementation simply being to mark the client as floating above all other windows and setting it to the size of the physical screen.

As part of debugging this issue this PR also improves logging in a number of places as well as adjusting logging levels so that the `debug` level is less verbose.

Closes #310