### PR TITLE
Add is_greedy and right_justified support to IntervalText widget"

### DIFF
--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -311,7 +311,7 @@ impl<X: XConn> Widget<X> for RefreshText {
 /// let my_widget = IntervalText::new(
 ///     style,
 ///     my_get_text,
-///     Duration::from_secs(60 * 5)
+///     Duration::from_secs(60 * 5),
 ///     true,
 ///     true
 /// );

--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -312,6 +312,8 @@ impl<X: XConn> Widget<X> for RefreshText {
 ///     style,
 ///     my_get_text,
 ///     Duration::from_secs(60 * 5)
+///     true,
+///     true
 /// );
 /// ```
 pub struct IntervalText {

--- a/crates/penrose_ui/src/bar/widgets/mod.rs
+++ b/crates/penrose_ui/src/bar/widgets/mod.rs
@@ -333,11 +333,17 @@ impl IntervalText {
     /// Construct a new [`IntervalText`] using the specified styling and a function for
     /// generating the widget contents. The function for updating the widget contents
     /// will be run in its own thread on the interval provided.
-    pub fn new<F>(style: TextStyle, get_text: F, interval: Duration) -> Self
+    pub fn new<F>(
+        style: TextStyle,
+        get_text: F,
+        interval: Duration,
+        is_greedy: bool,
+        right_justified: bool,
+    ) -> Self
     where
         F: Fn() -> Option<String> + Send + 'static,
     {
-        let inner = Arc::new(Mutex::new(Text::new("", style, false, false)));
+        let inner = Arc::new(Mutex::new(Text::new("", style, is_greedy, right_justified)));
 
         Self {
             inner,

--- a/crates/penrose_ui/src/bar/widgets/sys.rs
+++ b/crates/penrose_ui/src/bar/widgets/sys.rs
@@ -210,20 +210,26 @@ pub mod interval {
         style: TextStyle,
         interval: Duration,
     ) -> IntervalText {
-        IntervalText::new(style, move || helpers::battery_text(bat), interval)
+        IntervalText::new(
+            style,
+            move || helpers::battery_text(bat),
+            interval,
+            true,
+            true,
+        )
     }
 
     /// Display the current date and time in YYYY-MM-DD HH:MM format
     ///
     /// This widget shells out to the `date` tool to generate its output
     pub fn current_date_and_time(style: TextStyle, interval: Duration) -> IntervalText {
-        IntervalText::new(style, helpers::date_text, interval)
+        IntervalText::new(style, helpers::date_text, interval, true, true)
     }
 
     /// Display the ESSID currently connected to and the signal quality as
     /// a percentage.
     pub fn wifi_network(style: TextStyle, interval: Duration) -> IntervalText {
-        IntervalText::new(style, helpers::wifi_text, interval)
+        IntervalText::new(style, helpers::wifi_text, interval, true, true)
     }
 
     /// Display the current volume level as reported by `amixer`
@@ -232,6 +238,12 @@ pub mod interval {
         style: TextStyle,
         interval: Duration,
     ) -> IntervalText {
-        IntervalText::new(style, move || helpers::amixer_text(channel), interval)
+        IntervalText::new(
+            style,
+            move || helpers::amixer_text(channel),
+            interval,
+            true,
+            true,
+        )
     }
 }


### PR DESCRIPTION
I added  'is_greedy' and 'right_justified' to IntervalText widget since the only way to have the widgets rendered at the end of the bar is using a ActiveWindowName widget (isn't it?). 
I also  updated the example widgets with these changes.