### PR TITLE
Removing & renaming workspaces (includes status bar bug fixes)

### DIFF
--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -112,6 +112,7 @@ pub struct StatusBar<X: XConn> {
     screens: Vec<(Xid, u32)>,
     active_screen: usize,
     font: String,
+    redrawn: bool,
 }
 
 impl<X: XConn> StatusBar<X> {
@@ -135,6 +136,7 @@ impl<X: XConn> StatusBar<X> {
             screens: vec![],
             active_screen: 0,
             font: font.to_string(),
+            redrawn: false,
         })
     }
 
@@ -162,6 +164,7 @@ impl<X: XConn> StatusBar<X> {
             screens: vec![],
             active_screen: 0,
             font: font.to_string(),
+            redrawn: false,
         })
     }
 
@@ -277,6 +280,7 @@ impl<X: XConn> StatusBar<X> {
         for i in 0..self.screens.len() {
             self.redraw_screen(i)?;
         }
+        self.redrawn = true;
 
         Ok(())
     }
@@ -328,7 +332,15 @@ pub fn refresh_hook<X: XConn + 'static>(state: &mut State<X>, x: &X) -> penrose:
         }
     });
 
-    if let Err(e) = bar.redraw_if_needed() {
+    // the redrawn flag is set to false at the start of our event hook. If neither of the other
+    // hooks trigger a redraw then we force one now on refresh to ensure that we're up to date.
+    let res = if !bar.redrawn {
+        bar.redraw()
+    } else {
+        bar.redraw_if_needed()
+    };
+
+    if let Err(e) = res {
         error!(%e, "error redrawing status bar");
     }
 
@@ -345,6 +357,7 @@ pub fn event_hook<X: XConn + 'static>(
 
     let s = state.extension::<StatusBar<X>>()?;
     let mut bar = s.borrow_mut();
+    bar.redrawn = false;
 
     if matches!(event, RandrNotify) || matches!(event, ConfigureNotify(e) if e.is_root) {
         info!("screens have changed: recreating status bars");

--- a/crates/penrose_ui/src/bar/widgets/sys.rs
+++ b/crates/penrose_ui/src/bar/widgets/sys.rs
@@ -214,7 +214,7 @@ pub mod interval {
             style,
             move || helpers::battery_text(bat),
             interval,
-            true,
+            false,
             true,
         )
     }
@@ -223,13 +223,13 @@ pub mod interval {
     ///
     /// This widget shells out to the `date` tool to generate its output
     pub fn current_date_and_time(style: TextStyle, interval: Duration) -> IntervalText {
-        IntervalText::new(style, helpers::date_text, interval, true, true)
+        IntervalText::new(style, helpers::date_text, interval, false, true)
     }
 
     /// Display the ESSID currently connected to and the signal quality as
     /// a percentage.
     pub fn wifi_network(style: TextStyle, interval: Duration) -> IntervalText {
-        IntervalText::new(style, helpers::wifi_text, interval, true, true)
+        IntervalText::new(style, helpers::wifi_text, interval, false, true)
     }
 
     /// Display the current volume level as reported by `amixer`
@@ -242,7 +242,7 @@ pub mod interval {
             style,
             move || helpers::amixer_text(channel),
             interval,
-            true,
+            false,
             true,
         )
     }

--- a/crates/penrose_ui/src/bar/widgets/workspaces.rs
+++ b/crates/penrose_ui/src/bar/widgets/workspaces.rs
@@ -227,21 +227,22 @@ where
         let ui_updated = self.ui.update_from_state(&wss, &focused_ws, state, x);
         let tags_changed = self.tags_changed(&wss);
 
-        if ui_updated || tags_changed {
+        if ui_updated
+            || tags_changed
+            || self.focused_ws != focused_ws
+            || self.occupied_changed(&wss)
+        {
+            self.focused_ws = focused_ws;
+            self.workspaces = wss;
             self.require_draw = true;
             self.extent = None;
-        } else if self.focused_ws != focused_ws || self.occupied_changed(&wss) {
-            self.require_draw = true;
         }
-
-        self.focused_ws = focused_ws;
-        self.workspaces = wss;
     }
 
     fn tags_changed(&self, workspaces: &[WsMeta]) -> bool {
         let new_tags: Vec<&str> = workspaces.iter().map(|w| w.tag.as_ref()).collect();
 
-        self.raw_tags() == new_tags
+        self.raw_tags() != new_tags
     }
 
     // Called after tags_changed above so we assume that tags are matching

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,12 @@ pub enum Error {
     Randr(String),
 
     /// An operation was requested on a client window that is unknown
-    #[error("Client {0} is not in found")]
+    #[error("No client with id={0}")]
     UnknownClient(Xid),
+
+    /// An operation was requested on a workspace tag that is unknown
+    #[error("No workspace with tag={0}")]
+    UnknownWorkspace(String),
 
     /// A keybinding has been specified for an unknown key name for this machine.
     #[error("'{name}' is not a known key name")]

--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -562,6 +562,41 @@ where
         Ok(())
     }
 
+    /// Attempt to remove a [Workspace] from this [StackSet] by tag.
+    ///
+    /// Removing a workspace in this way will close all clients present on the workspace.
+    ///
+    /// If the workspace tag is unknown or if removal would result in insufficient workspaces
+    /// for the current number of screens then this method will return None, otherwise it will
+    /// return the Workspace that was removed.
+    pub fn remove_workspace(&mut self, tag: impl AsRef<str>) -> Option<Workspace<C>> {
+        let tag = tag.as_ref();
+
+        for s in self.screens.iter_mut() {
+            if s.workspace.tag != tag {
+                continue;
+            }
+
+            // If we don't have a replacement in hidden we cant remove
+            let mut ws = self.hidden.pop_front()?;
+            swap(&mut ws, &mut s.workspace);
+
+            if self.previous_tag == tag {
+                self.previous_tag = s.workspace.tag.clone();
+            }
+
+            return Some(ws);
+        }
+
+        let opt = pop_where!(self, hidden, |w: &Workspace<C>| w.tag == tag);
+
+        if self.previous_tag == tag {
+            self.previous_tag = self.screens.focus.workspace.tag.clone();
+        }
+
+        opt
+    }
+
     /// Add a new invisible [Workspace] to this [StackSet].
     ///
     /// It will not be possible to focus this workspace on a screen but its
@@ -1086,6 +1121,27 @@ pub mod tests {
         let visible_tags: Vec<&str> = s.screens().map(|s| s.workspace.tag.as_ref()).collect();
         assert_eq!(s.screens.focus.workspace.tag, "1");
         assert_eq!(visible_tags, &["1", "2"]);
+    }
+
+    #[test_case("1", "2", "2", Some("1"); "focused")]
+    #[test_case("2", "1", "1", Some("2"); "ws on other screen")]
+    #[test_case("3", "1", "1", Some("3"); "hidden")]
+    #[test_case("1", "1", "3", Some("1"); "focused when that is previous tag")]
+    #[test_case("3", "3", "1", Some("3"); "hidden when that is previous tag")]
+    #[test_case("?", "7", "7", None; "unknown tag")]
+    #[test]
+    fn remove_workspace_works(
+        tag: &str,
+        prev_tag: &str,
+        new_prev_tag: &str,
+        expected: Option<&str>,
+    ) {
+        let mut s = test_stack_set(5, 2);
+        s.previous_tag = prev_tag.to_string();
+        let maybe_ws = s.remove_workspace(tag);
+
+        assert_eq!(maybe_ws.map(|w| w.tag).as_deref(), expected);
+        assert_eq!(s.previous_tag, new_prev_tag);
     }
 
     #[test]

--- a/src/pure/stack_set.rs
+++ b/src/pure/stack_set.rs
@@ -535,6 +535,35 @@ where
         &self.screens.focus.workspace.tag
     }
 
+    /// Attempt to set a new tag for an existing [Workspace].
+    ///
+    /// This will error if the new tag collides with an existing one or if the
+    /// old tag is unknown.
+    pub fn try_rename_workspace(
+        &mut self,
+        old_tag: impl AsRef<str>,
+        new_tag: impl Into<String>,
+    ) -> Result<()> {
+        let new_tag = new_tag.into();
+        if old_tag.as_ref() == new_tag {
+            return Ok(());
+        }
+
+        if self.contains_tag(&new_tag) {
+            return Err(Error::NonUniqueTags {
+                tags: vec![new_tag],
+            });
+        }
+
+        match self.workspace_mut(old_tag.as_ref()) {
+            Some(ws) => {
+                ws.tag = new_tag;
+                Ok(())
+            }
+            None => Err(Error::UnknownWorkspace(old_tag.as_ref().to_string())),
+        }
+    }
+
     /// Add a new [Workspace] to this [StackSet].
     ///
     /// The id assigned to this workspace will be max(workspace ids) + 1.
@@ -1142,6 +1171,43 @@ pub mod tests {
 
         assert_eq!(maybe_ws.map(|w| w.tag).as_deref(), expected);
         assert_eq!(s.previous_tag, new_prev_tag);
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum RmWs {
+        Valid,
+        Unknown,
+        Conflict,
+    }
+
+    #[test_case("1", "foo", RmWs::Valid; "known to new")]
+    #[test_case("1", "1", RmWs::Valid; "known to itself")]
+    #[test_case("?", "foo", RmWs::Unknown; "unknown")]
+    #[test_case("1", "2", RmWs::Conflict; "conflicting")]
+    #[test_case("?", "1", RmWs::Conflict; "unknown to conflicting")]
+    #[test_case("invisible", "foo", RmWs::Valid; "invisible to new")]
+    #[test_case("invisible", "1", RmWs::Conflict; "invisible to conflicting")]
+    #[test]
+    fn try_rename_workspace_works(old_tag: &str, new_tag: &str, expected: RmWs) {
+        let mut s = test_stack_set(5, 2);
+        s.add_invisible_workspace("invisible").unwrap();
+
+        let res = s.try_rename_workspace(old_tag, new_tag);
+
+        match res {
+            Ok(_) => {
+                assert_eq!(expected, RmWs::Valid);
+                assert!(s.contains_tag(new_tag), "should contain the new tag");
+                if old_tag != new_tag {
+                    assert!(!s.contains_tag(old_tag), "should not contain the old tag");
+                }
+            }
+
+            Err(Error::UnknownWorkspace(_)) => assert_eq!(expected, RmWs::Unknown),
+            Err(Error::NonUniqueTags { .. }) => assert_eq!(expected, RmWs::Conflict),
+
+            _ => panic!("unexpected error returned: {res:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #324

This adds two new pieces of functionality around manipulating workspaces:
- removing workspaces from a stackset
- renaming an existing workspace

Also, in 7b44c4a74edf3bd1e31c2f1d0c9acb70d2c48b7a, there are some bug fixes for the status bar logic addressing a couple of issues that were encountered during testing. One comes from incorrect defaults added in #322 (that I didn't catch during review) but the other is related to a couple of bugs that were partially cancelling one another out.
The check for whether or not the workspace names had changed in the [Workspaces widget](https://github.com/sminez/penrose/blob/c734944abd14f20441e0253a49fdb3f507cbf0fb/crates/penrose_ui/src/bar/widgets/workspaces.rs#L179) was inverted, leading to more frequent re-rendering of the status bar than needed. Fixing this then exposed that _something_ is causing the bar to fail to correctly re-render after clearing, but its not error logging anywhere which is surprising (to say the least). Almost certainly this will be down to the underlying `Draw` logic having some edge cases I've not handled correctly at the C FFI layer and tracking that down is proving to be pretty tricky.
What I have now as part of this PR is a mechanism for ensuring that the status bar re-renders at least once per pass through the main window manager event loop, which matches the previous re-render frequency for status bars using the `Workspaces` widget (effectively all status bars) but with an added fix for this weird rendering issue reported by @saithe6:

![broken-penrose-status-bar](https://github.com/user-attachments/assets/0b26f42c-6f58-4a70-8d63-e1cf65c4bac4)

This was being caused by the [update_from_state](https://github.com/sminez/penrose/blob/develop/crates/penrose_ui/src/bar/widgets/workspaces.rs#L220) method in the workspace logic incorrectly leaving zero sized elements in the widget state without forcing re-computation of the widget extent.

### tl;dr
- New functionality from #324 added
- Rendering issues in status bar fixed but there's potentially something more going on there