### PR TITLE
fix: position status bar correctly on vertically stacked screens

### DIFF
--- a/crates/penrose_ui/src/bar/mod.rs
+++ b/crates/penrose_ui/src/bar/mod.rs
@@ -202,7 +202,7 @@ impl<X: XConn> StatusBar<X> {
                 let bar_h = self.widgets.for_screen_mut(i).h;
                 let y = match self.position {
                     Position::Top => y,
-                    Position::Bottom => (h - bar_h) as i32,
+                    Position::Bottom => y + (h - bar_h) as i32,
                 };
 
                 debug!("creating new window");


### PR DESCRIPTION
Before status bar was positioned incorrectly because it didn't account for screen y position and assumed it was 0, now it takes account of screen y position.

Tested locally where screens are vertically stacked:
```
xrandr --output HDMI-1-0 --above eDP-1
Monitors: 2
 0: +*eDP-1 1920/345x1200/215+0+1080  eDP-1
 1: +*HDMI-1-0 1920/527x1080/296+0+0  HDMI-1-0
```