### PR TITLE
add startup hook to fix #329

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -595,7 +595,7 @@ fn manage_existing_clients<X: XConn>(state: &mut State<X>, x: &X) -> Result<()> 
     let first_tag = state.client_set.ordered_tags()[0].clone();
 
     for id in x.existing_clients()? {
-        if !state.client_set.contains(&id) && client_should_be_manged(id, x) {
+        if !state.client_set.contains(&id) && client_should_be_managed(id, x) {
             let workspace_id = match x.get_prop(id, Atom::NetWmDesktop.as_ref()) {
                 Ok(Some(Prop::Cardinal(ids))) => ids[0] as usize,
                 _ => 0, // we know that we always have at least one workspace
@@ -630,7 +630,7 @@ fn manage_existing_clients<X: XConn>(state: &mut State<X>, x: &X) -> Result<()> 
 
 /// For a given existing client being processed on startup, determine whether we need
 /// to bring it into our internal state and manage it.
-fn client_should_be_manged<X: XConn>(id: Xid, x: &X) -> bool {
+pub(crate) fn client_should_be_managed<X: XConn>(id: Xid, x: &X) -> bool {
     let attrs = match x.get_window_attributes(id) {
         Ok(attrs) => attrs,
         _ => {

--- a/src/extensions/actions/mod.rs
+++ b/src/extensions/actions/mod.rs
@@ -68,8 +68,12 @@ pub fn set_fullscreen_state<X: XConn>(
 ///
 /// **NOTE**: You will need to make use of [add_ewmh_hooks][0] for this action to
 ///           work correctly.
+///           Additionally you can use the [ClearFsPropOnStartup][1] hook to prevent
+///           existing clients from having an inconsistent fullscreen state after
+///           restarting penrose while they are fullscreen.
 ///
 ///   [0]: crate::extensions::hooks::add_ewmh_hooks
+///   [1]: crate::extensions::hooks::startup::ClearFsPropOnStartup
 pub fn toggle_fullscreen<X: XConn>() -> Box<dyn KeyEventHandler<X>> {
     key_handler(|state, x: &X| {
         let id = match state.client_set.current_client() {

--- a/src/extensions/hooks/startup.rs
+++ b/src/extensions/hooks/startup.rs
@@ -1,8 +1,8 @@
 //! Startup hooks for direct adding to your penrose config.
 use crate::{
-    core::{hooks::StateHook, State},
+    core::{self, hooks::StateHook, State},
     util::spawn,
-    x::XConn,
+    x::{Atom, Prop, XConn},
     Result,
 };
 use std::borrow::Cow;
@@ -34,5 +34,45 @@ where
 {
     fn call(&mut self, _state: &mut State<X>, _x: &X) -> Result<()> {
         spawn(self.prog.as_ref())
+    }
+}
+
+/// Remove _NET_WM_STATE_FULLSCREEN property from existing clients, not present in
+/// [client_set][0], on window manager startup.
+///
+///   [0]: crate::core::State::client_set
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClearFsPropOnStartup;
+
+impl ClearFsPropOnStartup {
+    /// Create a new startup hook ready for adding to your Config
+    pub fn boxed<X>() -> Box<dyn StateHook<X>>
+    where
+        X: XConn,
+    {
+        Box::new(Self)
+    }
+}
+
+impl<X> StateHook<X> for ClearFsPropOnStartup
+where
+    X: XConn,
+{
+    fn call(&mut self, state: &mut State<X>, x: &X) -> Result<()> {
+        for id in x.existing_clients()? {
+            if !state.client_set.contains(&id) && core::client_should_be_managed(id, x) {
+                let net_wm_state = Atom::NetWmState.as_ref();
+                let full_screen = x.intern_atom(Atom::NetWmStateFullscreen.as_ref())?;
+                let mut wstate = match x.get_prop(id, net_wm_state) {
+                    Ok(Some(Prop::Cardinal(vals))) => vals,
+                    _ => vec![],
+                };
+                if wstate.contains(&full_screen) {
+                    wstate.retain(|&val| val != *full_screen);
+                    x.set_prop(id, net_wm_state, Prop::Cardinal(wstate))?;
+                }
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
- Add a startup hook to remove `_NET_WM_STATE_FULLSCREEN` property from existing clients at startup.
- Make `core::client_should_be_managed` public to use in `extensions::hooks::startup::ClearFsPropOnStartup::call`.
- Fix small typo to make `core::client_should_be_managed` show up when searching for manage.
- Update documentation to point users from `extensions::actions::toggle_fullscreen` to the new hook.