### PR TITLE
Skip unmanage for clients not in the managed set (prevents duplicates)

### DIFF
--- a/src/x/mod.rs
+++ b/src/x/mod.rs
@@ -168,17 +168,18 @@ pub trait XConnExt: XConn + Sized {
     fn unmanage(&self, client: Xid, state: &mut State<Self>) -> Result<()> {
         let current_focus = state.client_set.current_client();
         let contains_client = state.client_set.contains(&client);
+
+        if !contains_client {
+            trace!(client = ?client, "client not in managed set, skipping unmanage");
+            return Ok(());
+        }
+
         trace!(
             client = %client,
             current_focus = ?current_focus,
             contains_client,
             "unmanaging client"
         );
-
-        if !contains_client {
-            trace!(client = ?client, "client not in managed set, skipping unmanage");
-            return Ok(());
-        }
 
         self.modify_and_refresh(state, |cs| {
             cs.remove_client(&client);

--- a/src/x/mod.rs
+++ b/src/x/mod.rs
@@ -166,7 +166,20 @@ pub trait XConnExt: XConn + Sized {
     /// Remove the window manager state for the given client window and refresh the
     /// current X state.
     fn unmanage(&self, client: Xid, state: &mut State<Self>) -> Result<()> {
-        trace!(?client, "removing client");
+        let current_focus = state.client_set.current_client();
+        let contains_client = state.client_set.contains(&client);
+        trace!(
+            client = %client,
+            current_focus = ?current_focus,
+            contains_client,
+            "unmanaging client"
+        );
+
+        if !contains_client {
+            trace!(client = ?client, "client not in managed set, skipping unmanage");
+            return Ok(());
+        }
+
         self.modify_and_refresh(state, |cs| {
             cs.remove_client(&client);
         })


### PR DESCRIPTION
The main bug was logging "focused client changed" whenever any client had focus instead of when the focus actually changed.

This allows Jetbrains IDE widgets like "Show Context Actions" popups, or the "search everywhere" dialog to correctly return focus to the editor without causing the caret to disappear.

PS thanks @sminez for a delightful day of learning Rust, and a fun youtube series.  You're a cool guy.