### PR TITLE
Fix JetBrains IDE focus issues

### DIFF
--- a/src/x/mod.rs
+++ b/src/x/mod.rs
@@ -166,7 +166,21 @@ pub trait XConnExt: XConn + Sized {
     /// Remove the window manager state for the given client window and refresh the
     /// current X state.
     fn unmanage(&self, client: Xid, state: &mut State<Self>) -> Result<()> {
-        trace!(?client, "removing client");
+        let current_focus = state.client_set.current_client();
+        let contains_client = state.client_set.contains(&client);
+
+        if !contains_client {
+            trace!(client = ?client, "client not in managed set, skipping unmanage");
+            return Ok(());
+        }
+
+        trace!(
+            client = %client,
+            current_focus = ?current_focus,
+            contains_client,
+            "unmanaging client"
+        );
+
         self.modify_and_refresh(state, |cs| {
             cs.remove_client(&client);
         })

--- a/src/x/mod.rs
+++ b/src/x/mod.rs
@@ -6,7 +6,11 @@ use crate::{
         ClientSet, Config, State,
     },
     pure::geometry::{Point, Rect},
-    x::{atom::AUTO_FLOAT_WINDOW_TYPES, event::ClientMessage, property::WmState},
+    x::{
+        atom::AUTO_FLOAT_WINDOW_TYPES,
+        event::{ClientMessage, ClientMessageKind},
+        property::{WmHints, WmState},
+    },
     Color, Result, Xid,
 };
 #[cfg(feature = "serde")]
@@ -644,8 +648,24 @@ fn set_window_visibility<X: XConn>(x: &X, state: &mut State<X>) -> Result<()> {
 
 fn set_focus<X: XConn>(x: &X, state: &mut State<X>) -> Result<()> {
     if let Some(&id) = state.client_set.current_client() {
-        x.focus(id)
+        trace!(?id, "setting X11 focus to client");
+
+        // Use the same ICCCM focus protocol as focus_in handler
+        let accepts_input = match x.get_prop(id, Atom::WmHints.as_ref()) {
+            Ok(Some(Prop::WmHints(WmHints { accepts_input, .. }))) => accepts_input,
+            _ => true,
+        };
+
+        if accepts_input {
+            trace!(?id, accepts_input, "using direct focus (XSetInputFocus)");
+            x.focus(id)
+        } else {
+            trace!(?id, accepts_input, "using WM_TAKE_FOCUS protocol");
+            let msg = ClientMessageKind::TakeFocus(id).as_message(x)?;
+            x.send_client_message(msg)
+        }
     } else {
+        trace!("setting X11 focus to root window");
         x.focus(state.root)
     }
 }


### PR DESCRIPTION
- right-click menu and context-actions popup display correctly
- find-in-files and search-everywhere dialogs are correctly focused
- switching between windows no longer causes caret to disappear

I tested with focus_follow_mouse both true and false, it seems to work fine,

Please tell me if I got anything wrong!  X and Rust are both new to me.